### PR TITLE
feat: add support for user-configurable build methods and custom Dockerfile paths

### DIFF
--- a/src/client/api.ts
+++ b/src/client/api.ts
@@ -32,6 +32,8 @@ export type Service = {
   databasePublicEnabled: boolean;
   databasePublicHostname: null | string;
   postgresLogicalReplicationEnabled: boolean;
+  buildMethod: "railpack" | "dockerfile";
+  dockerfilePath: string;
   status: string;
   reachable: boolean;
   localUrl: string;

--- a/src/client/features/services/service-page-shell.tsx
+++ b/src/client/features/services/service-page-shell.tsx
@@ -119,7 +119,9 @@ export function ServicePageShell({
     internalPort: 8080,
     databasePublicEnabled: true,
     databasePublicHostname: "",
-    postgresLogicalReplicationEnabled: false
+    postgresLogicalReplicationEnabled: false,
+    buildMethod: "railpack" as "railpack" | "dockerfile",
+    dockerfilePath: "Dockerfile"
   });
   const [settingsBranches, setSettingsBranches] = useState<string[]>([]);
   const [branchMenuOpen, setBranchMenuOpen] = useState(false);
@@ -173,7 +175,9 @@ export function ServicePageShell({
           internalPort: result.service.internalPort,
           databasePublicEnabled: result.service.databasePublicEnabled,
           databasePublicHostname: result.service.databasePublicHostname ?? "",
-          postgresLogicalReplicationEnabled: result.service.postgresLogicalReplicationEnabled
+          postgresLogicalReplicationEnabled: result.service.postgresLogicalReplicationEnabled,
+          buildMethod: result.service.buildMethod ?? "railpack",
+          dockerfilePath: result.service.dockerfilePath ?? "Dockerfile"
         });
         setError("");
         setOverviewLoading(false);
@@ -421,7 +425,9 @@ export function ServicePageShell({
         internalPort: Number(settings.internalPort),
         databasePublicEnabled: isDatabase ? true : undefined,
         databasePublicHostname: isDatabase ? settings.databasePublicHostname || undefined : undefined,
-        postgresLogicalReplicationEnabled: isDatabase ? settings.postgresLogicalReplicationEnabled : undefined
+        postgresLogicalReplicationEnabled: isDatabase ? settings.postgresLogicalReplicationEnabled : undefined,
+        buildMethod: isDatabase || isDockerImage ? undefined : settings.buildMethod,
+        dockerfilePath: isDatabase || isDockerImage ? undefined : (settings.buildMethod === "dockerfile" ? (settings.dockerfilePath.trim() || "Dockerfile") : undefined)
       });
     });
   }
@@ -806,6 +812,57 @@ export function ServicePageShell({
                             <FormInput value={settings.staticOutput} onChange={(event) => setSettings({ ...settings, staticOutput: event.target.value })} placeholder="auto" />
                           </div>
                         ) : null}
+
+                        {/* Build Method */}
+                        <div className="xl:col-span-2">
+                          <FieldLabel>Build method</FieldLabel>
+                          <div className="space-y-3 border border-zinc-700 bg-zinc-900/88 p-4">
+                            <div className="flex gap-3">
+                              <button
+                                type="button"
+                                id="build-method-railpack"
+                                onClick={() => setSettings((s) => ({ ...s, buildMethod: "railpack" }))}
+                                className={`flex-1 border px-4 py-3 text-left text-sm transition ${
+                                  settings.buildMethod === "railpack"
+                                    ? "border-[#4FB8B2]/60 bg-[#4FB8B2]/10 text-[#7fe3dd]"
+                                    : "border-zinc-700 bg-zinc-900 text-zinc-400 hover:border-zinc-600 hover:text-zinc-200"
+                                }`}
+                              >
+                                <div className="font-semibold">Railpack (default)</div>
+                                <div className="mt-1 text-xs opacity-70">Auto-detects language and framework. No Dockerfile needed.</div>
+                              </button>
+                              <button
+                                type="button"
+                                id="build-method-dockerfile"
+                                onClick={() => setSettings((s) => ({ ...s, buildMethod: "dockerfile" }))}
+                                className={`flex-1 border px-4 py-3 text-left text-sm transition ${
+                                  settings.buildMethod === "dockerfile"
+                                    ? "border-[#4FB8B2]/60 bg-[#4FB8B2]/10 text-[#7fe3dd]"
+                                    : "border-zinc-700 bg-zinc-900 text-zinc-400 hover:border-zinc-600 hover:text-zinc-200"
+                                }`}
+                              >
+                                <div className="font-semibold">Dockerfile</div>
+                                <div className="mt-1 text-xs opacity-70">Uses your Dockerfile via <code className="font-mono">docker build</code>. Bypasses Railpack.</div>
+                              </button>
+                            </div>
+                            {settings.buildMethod === "dockerfile" ? (
+                              <div>
+                                <div className="mb-1.5 text-xs text-zinc-400">Dockerfile path (relative to root directory)</div>
+                                <FormInput
+                                  id="dockerfile-path"
+                                  value={settings.dockerfilePath}
+                                  onChange={(event) => setSettings({ ...settings, dockerfilePath: event.target.value })}
+                                  placeholder="Dockerfile"
+                                />
+                              </div>
+                            ) : null}
+                            {settings.buildMethod === "railpack" ? (
+                              <p className="text-xs text-zinc-500">
+                                Aeroplane will automatically switch to Dockerfile mode if a <code className="font-mono text-zinc-400">Dockerfile</code> is detected in the repo at deploy time.
+                              </p>
+                            ) : null}
+                          </div>
+                        </div>
                       </>
                     )}
                   </div>

--- a/src/server/db.ts
+++ b/src/server/db.ts
@@ -217,6 +217,14 @@ if (!hasColumn("projects", "postgres_logical_replication_enabled")) {
   sqlite.exec("ALTER TABLE projects ADD COLUMN postgres_logical_replication_enabled INTEGER NOT NULL DEFAULT 0");
 }
 
+if (!hasColumn("projects", "build_method")) {
+  sqlite.exec("ALTER TABLE projects ADD COLUMN build_method TEXT NOT NULL DEFAULT 'railpack'");
+}
+
+if (!hasColumn("projects", "dockerfile_path")) {
+  sqlite.exec("ALTER TABLE projects ADD COLUMN dockerfile_path TEXT NOT NULL DEFAULT 'Dockerfile'");
+}
+
 if (!hasColumn("database_backups", "trigger")) {
   sqlite.exec("ALTER TABLE database_backups ADD COLUMN trigger TEXT NOT NULL DEFAULT 'manual'");
 }

--- a/src/server/deploy.ts
+++ b/src/server/deploy.ts
@@ -202,6 +202,22 @@ function cloneUrlWithToken(repoUrl: string, token?: string | null) {
   return url.toString();
 }
 
+// Detect whether the cloned source has a Dockerfile at a given path.
+// Returns the resolved dockerfile path relative to appDir, or null if not found.
+function detectDockerfilePath(appDir: string, configuredPath: string): string | null {
+  const candidates = [
+    configuredPath,
+    "Dockerfile",
+    "dockerfile"
+  ];
+  for (const candidate of candidates) {
+    if (existsSync(join(appDir, candidate))) {
+      return candidate;
+    }
+  }
+  return null;
+}
+
 async function ensureBuildkitAvailable(deploymentId: string) {
   const recovery = await ensureBuildkitRunning(config.buildkitHost);
   if (recovery.ok) {
@@ -1139,27 +1155,94 @@ async function runDeployment(deployment: Deployment, service: Service) {
     if (hasCommandOverrides) {
       appendDeploymentLog(deployment.id, "Applying command overrides through Railpack.");
     }
-    await ensureBuildkitAvailable(deployment.id);
-    const railpackArgs = ["build", "--name", imageTag, "--progress", "plain", "--cache-key", service.id];
-    railpackArgs.push(...railpackBuildEnvArgs(buildEnv));
-    const railpackConfigFile = railpackEnv.RAILPACK_CONFIG_FILE;
-    if (railpackConfigFile) {
-      appendDeploymentLog(deployment.id, `Using Railpack config file: ${railpackConfigFile}`, "system", secrets);
-      railpackArgs.push("--config-file", railpackConfigFile);
+
+    // --- Build method dispatch ---
+    // The stored buildMethod is either "railpack" (default) or "dockerfile".
+    // When set to "railpack" we additionally check whether the repo actually has a
+    // Dockerfile — if it does, we promote the method to "dockerfile" automatically
+    // and persist that discovery so it is shown in the UI.
+    const storedBuildMethod = (service.buildMethod ?? "railpack") as "railpack" | "dockerfile";
+    const storedDockerfilePath = service.dockerfilePath ?? "Dockerfile";
+
+    let resolvedBuildMethod = storedBuildMethod;
+    let resolvedDockerfilePath = storedDockerfilePath;
+
+    if (storedBuildMethod === "railpack") {
+      const detectedDockerfile = detectDockerfilePath(appDir, storedDockerfilePath);
+      if (detectedDockerfile) {
+        resolvedBuildMethod = "dockerfile";
+        resolvedDockerfilePath = detectedDockerfile;
+        appendDeploymentLog(deployment.id, `Detected Dockerfile at ${detectedDockerfile}. Switching build method to docker build.`);
+        // Persist the discovered method so the UI reflects it.
+        db.update(services)
+          .set({ buildMethod: "dockerfile", dockerfilePath: resolvedDockerfilePath, updatedAt: now() })
+          .where(eq(services.id, service.id))
+          .run();
+      }
     }
-    if (buildCommand) {
-      railpackArgs.push("--build-cmd", buildCommand);
+
+    if (resolvedBuildMethod === "dockerfile") {
+      // --- Dockerfile build path ---
+      const absoluteDockerfilePath = join(appDir, resolvedDockerfilePath);
+      if (!existsSync(absoluteDockerfilePath)) {
+        throw new Error(`Dockerfile not found at ${resolvedDockerfilePath}. Update the Dockerfile path in service settings or switch the build method to Railpack.`);
+      }
+
+      appendDeploymentLog(deployment.id, `Building image with Dockerfile: ${resolvedDockerfilePath}`);
+      await ensureDockerAvailable(deployment.id);
+
+      const dockerBuildArgs = [
+        "build",
+        "--file", absoluteDockerfilePath,
+        "--tag", imageTag,
+        "--progress", "plain"
+      ];
+
+      // Pass service env vars as build args so ARG declarations in the Dockerfile
+      // can pick them up. We use the same env vars that Railpack would see.
+      for (const [key, value] of Object.entries(buildEnv)) {
+        dockerBuildArgs.push("--build-arg", `${key}=${value}`);
+      }
+
+      dockerBuildArgs.push(appDir);
+
+      await runCommand(
+        "docker",
+        dockerBuildArgs,
+        deployment.id,
+        {
+          env: {
+            DOCKER_BUILDKIT: "1",
+            // Reuse Aeroplane's BuildKit daemon when it is a TCP address
+            ...(config.buildkitHost.startsWith("tcp://") ? { BUILDKIT_HOST: config.buildkitHost } : {})
+          },
+          redact: secrets
+        }
+      );
+    } else {
+      // --- Railpack build path (default) ---
+      await ensureBuildkitAvailable(deployment.id);
+      const railpackArgs = ["build", "--name", imageTag, "--progress", "plain", "--cache-key", service.id];
+      railpackArgs.push(...railpackBuildEnvArgs(buildEnv));
+      const railpackConfigFile = railpackEnv.RAILPACK_CONFIG_FILE;
+      if (railpackConfigFile) {
+        appendDeploymentLog(deployment.id, `Using Railpack config file: ${railpackConfigFile}`, "system", secrets);
+        railpackArgs.push("--config-file", railpackConfigFile);
+      }
+      if (buildCommand) {
+        railpackArgs.push("--build-cmd", buildCommand);
+      }
+      if (startCommand) {
+        railpackArgs.push("--start-cmd", startCommand);
+      }
+      railpackArgs.push(appDir);
+      await runCommand(
+        "railpack",
+        railpackArgs,
+        deployment.id,
+        { env: railpackEnv, redact: secrets }
+      );
     }
-    if (startCommand) {
-      railpackArgs.push("--start-cmd", startCommand);
-    }
-    railpackArgs.push(appDir);
-    await runCommand(
-      "railpack",
-      railpackArgs,
-      deployment.id,
-      { env: railpackEnv, redact: secrets }
-    );
 
     if (isStaticService) {
       await runCommand("docker", ["rm", "-f", containerName], deployment.id).catch(() => {

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -400,7 +400,9 @@ const updateServiceSchema = z.object({
   internalPort: z.coerce.number().int().min(1).max(65535).optional(),
   databasePublicEnabled: z.boolean().optional(),
   databasePublicHostname: publicHostnameSchema,
-  postgresLogicalReplicationEnabled: z.boolean().optional()
+  postgresLogicalReplicationEnabled: z.boolean().optional(),
+  buildMethod: z.enum(["railpack", "dockerfile"]).optional(),
+  dockerfilePath: z.string().trim().min(1).max(255).optional()
 });
 const transferServiceSchema = z.object({
   targetProjectId: z.string().trim().min(1)
@@ -638,6 +640,8 @@ async function publicService(service: Service) {
     databasePublicEnabled: Boolean(service.databasePublicEnabled),
     databasePublicHostname: service.databasePublicHostname,
     postgresLogicalReplicationEnabled: Boolean(service.postgresLogicalReplicationEnabled),
+    buildMethod: (service.buildMethod ?? "railpack") as "railpack" | "dockerfile",
+    dockerfilePath: service.dockerfilePath ?? "Dockerfile",
     status: liveStatus,
     reachable,
     localUrl,

--- a/src/server/schema.ts
+++ b/src/server/schema.ts
@@ -31,6 +31,8 @@ export const services = sqliteTable("projects", {
   databasePublicEnabled: integer("database_public_enabled", { mode: "boolean" }).notNull().default(false),
   databasePublicHostname: text("database_public_hostname"),
   postgresLogicalReplicationEnabled: integer("postgres_logical_replication_enabled", { mode: "boolean" }).notNull().default(false),
+  buildMethod: text("build_method").notNull().default("railpack"),
+  dockerfilePath: text("dockerfile_path").notNull().default("Dockerfile"),
   status: text("status").notNull(),
   lastDeployedAt: text("last_deployed_at"),
   createdAt: text("created_at").notNull(),


### PR DESCRIPTION
## Add Dockerfile build path alongside Railpack

Closes #1 

Aeroplane previously only supported building via Railpack (BuildKit LLB). This PR adds a fully separate **Dockerfile build path** using `docker build`, so repos that ship their own `Dockerfile` now work without any workarounds.

---

### What changed

#### Auto-detection
At deploy time, after the repo is cloned, Aeroplane checks for a `Dockerfile` in the app directory. If one is found and the service is still set to `railpack`, the build automatically switches to `dockerfile` mode — and that discovery is **persisted to the database** so the Settings tab reflects it on the next load.

#### Two build paths, one container runtime
```
clone repo
     │
     ├── Dockerfile detected / mode = "dockerfile"
     │       └── docker build -f Dockerfile -t <image> .   (DOCKER_BUILDKIT=1)
     │
     └── no Dockerfile / mode = "railpack"
             └── railpack build --name <image> ...
     │
     ▼
docker run <image>   ← identical from here on
```
Both paths produce the same tagged Docker image, so zero-downtime rollout, Caddy hot-reload, health probing, worker mode, and static site export are completely unchanged.

#### Build-arg passthrough
When building with a Dockerfile, service env vars are forwarded as `--build-arg` flags so `ARG` declarations in the Dockerfile can pick them up (same vars Railpack would receive).

#### BuildKit reuse
If `BUILDKIT_HOST` points to a TCP address (Aeroplane's embedded BuildKit daemon), `docker build` will use it via `BUILDKIT_HOST` env, keeping caching consistent.

---

### Database migration
Two new columns are added to the `projects` table with safe `ALTER TABLE … ADD COLUMN` migrations (no destructive changes):

| Column | Type | Default |
|---|---|---|
| `build_method` | `TEXT` | `'railpack'` |
| `dockerfile_path` | `TEXT` | `'Dockerfile'` |

All existing services continue to use Railpack unless a Dockerfile is detected.

---

### Settings UI
A **Build method** toggle appears in the service Settings tab for Git-backed services:

- **Railpack (default)** — auto-detects language/framework, no Dockerfile needed
- **Dockerfile** — runs `docker build`, bypasses Railpack entirely; exposes a **Dockerfile path** input for non-standard locations (e.g. `docker/Dockerfile.prod`)

A hint in Railpack mode explains the auto-detection behaviour.

---

### What's explicitly NOT supported
Railpack does not support Dockerfiles internally (it uses BuildKit LLB directly). The two paths are mutually exclusive by design — switching to Dockerfile mode fully bypasses Railpack.

---

### Testing checklist
- [ ] Service with `Dockerfile` at root auto-switches on first deploy
- [ ] Service without `Dockerfile` uses Railpack as before
- [ ] Manual override to `dockerfile` in Settings is persisted and respected
- [ ] Custom `dockerfilePath` (e.g. `infra/Dockerfile`) is respected
- [ ] Build-args are forwarded correctly to `ARG` declarations in the Dockerfile
- [ ] Zero-downtime swap, worker mode, and static sites still work post-build
- [ ] Existing services are unaffected (migration defaults to `railpack`)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds user-selectable build methods (`railpack` or Dockerfile) with support for custom Dockerfile paths and automatic detection at deploy time. Repos with a `Dockerfile` now build via `docker build` while keeping the same image, rollout, and runtime behavior.

- **New Features**
  - Auto-detect a `Dockerfile` on deploy; switch to `dockerfile` mode and persist it so Settings reflects the change.
  - Settings UI: Build method toggle and `Dockerfile` path input; hint explains auto-detect when in `railpack` mode.
  - Dockerfile builds use `docker build` with `DOCKER_BUILDKIT=1`; reuse external BuildKit when `BUILDKIT_HOST` is a TCP address.
  - Service env vars are forwarded as `--build-arg` so `ARG` values work in the Dockerfile.
  - Both build paths output the same tagged image; rollout, health checks, workers, and static export are unchanged.
  - API/DB: add `buildMethod` and `dockerfilePath` to service payloads; add `build_method` and `dockerfile_path` columns and defaults.

- **Migration**
  - No breaking changes: defaults to `railpack` with `dockerfilePath` = `Dockerfile`.
  - Existing services stay on `railpack`; if a `Dockerfile` is present, the next deploy auto-switches and persists the mode.
  - To use a non-standard path, set `dockerfilePath` in Settings; if the path is invalid, the build will fail with guidance to update the path or switch back to `railpack`.

<sup>Written for commit fc3aa4a65f8cc702cd65a5722f5d69233a51ff7d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/xt42io/aeroplane/pull/2?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

