### PR TITLE
Add rate limiting to auth endpoints

### DIFF
--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -28,6 +28,7 @@ import { getRailwayProjects, getRailwayProjectDetails, importRailwayProject } fr
 import { startRailwayImportAutomation } from "./railway-import-automation.js";
 import { githubConnectionStatus, listConnectedRepos, listRepoBranches, listRepoDirectories, repoUrlFromFullName } from "./github-connect.js";
 import { branchFromGitRef, verifyGitHubSignature } from "./github.js";
+import { rateLimit } from "./rate-limit.js";
 import { subscribeToDeploymentLogs } from "./logBus.js";
 import {
   buildDatabaseConnectionUrl,
@@ -1105,7 +1106,7 @@ async function applyOnboardingSettings(input: z.infer<typeof restartOnboardingSc
 
 app.get("/api/auth/status", (c) => c.json(publicAuthStatus(c)));
 
-app.post("/api/auth/setup", async (c) => {
+app.post("/api/auth/setup", rateLimit, async (c) => {
   if (hasAuthUsers()) {
     return jsonError("Aeroplane has already been set up", 409);
   }
@@ -1127,7 +1128,7 @@ app.post("/api/auth/setup", async (c) => {
   return c.json({ ok: true, user: publicUser(user), envPath, restartRequired: true }, 201);
 });
 
-app.post("/api/auth/migration/import", async (c) => {
+app.post("/api/auth/migration/import", rateLimit, async (c) => {
   if (hasAuthUsers()) {
     return jsonError("Aeroplane has already been set up", 409);
   }
@@ -1155,7 +1156,7 @@ app.post("/api/auth/migration/import", async (c) => {
   }
 });
 
-app.post("/api/auth/login", async (c) => {
+app.post("/api/auth/login", rateLimit, async (c) => {
   if (!hasAuthUsers()) {
     return jsonError("Setup required", 401);
   }

--- a/src/server/rate-limit.ts
+++ b/src/server/rate-limit.ts
@@ -1,0 +1,31 @@
+import type { Context, Next } from "hono";
+
+const MAX_ATTEMPTS = 10;
+const WINDOW_MS = 60_000;
+
+const buckets = new Map<string, { count: number; resetAt: number }>();
+
+export function rateLimit(c: Context, next: Next) {
+  const ip = c.req.header("x-forwarded-for")?.split(",")[0]?.trim()
+    ?? c.req.header("x-real-ip")
+    ?? "127.0.0.1";
+
+  const now = Date.now();
+  let bucket = buckets.get(ip);
+
+  if (!bucket || bucket.resetAt <= now) {
+    bucket = { count: 0, resetAt: now + WINDOW_MS };
+    buckets.set(ip, bucket);
+  }
+
+  bucket.count++;
+  c.res.headers.set("X-RateLimit-Limit", String(MAX_ATTEMPTS));
+  c.res.headers.set("X-RateLimit-Remaining", String(Math.max(0, MAX_ATTEMPTS - bucket.count)));
+  c.res.headers.set("X-RateLimit-Reset", String(Math.ceil(bucket.resetAt / 1000)));
+
+  if (bucket.count > MAX_ATTEMPTS) {
+    return c.json({ error: "Rate limit exceeded. Try again shortly." }, 429);
+  }
+
+  return next();
+}

--- a/src/server/rate-limit.ts
+++ b/src/server/rate-limit.ts
@@ -2,15 +2,49 @@ import type { Context, Next } from "hono";
 
 const MAX_ATTEMPTS = 10;
 const WINDOW_MS = 60_000;
+const MAX_BUCKETS = 10_000;
 
-const buckets = new Map<string, { count: number; resetAt: number }>();
+type Bucket = { count: number; resetAt: number };
+
+const buckets = new Map<string, Bucket>();
+let lastPruneAt = 0;
+
+function pruneBuckets(now: number) {
+  if (now - lastPruneAt < WINDOW_MS && buckets.size < MAX_BUCKETS) return;
+  lastPruneAt = now;
+
+  for (const [ip, bucket] of buckets) {
+    if (bucket.resetAt <= now) buckets.delete(ip);
+  }
+
+  if (buckets.size <= MAX_BUCKETS) return;
+
+  const excess = buckets.size - MAX_BUCKETS;
+  const oldest = [...buckets.entries()]
+    .sort((a, b) => a[1].resetAt - b[1].resetAt)
+    .slice(0, excess);
+
+  for (const [ip] of oldest) {
+    buckets.delete(ip);
+  }
+}
+
+function clientIp(c: Context) {
+  const forwardedFor = c.req.header("x-forwarded-for");
+  if (forwardedFor) {
+    const forwardedChain = forwardedFor.split(",").map((part) => part.trim()).filter(Boolean);
+    const proxyReportedIp = forwardedChain.at(-1);
+    if (proxyReportedIp) return proxyReportedIp;
+  }
+
+  return c.req.header("x-real-ip")?.trim() || "unknown";
+}
 
 export function rateLimit(c: Context, next: Next) {
-  const ip = c.req.header("x-forwarded-for")?.split(",")[0]?.trim()
-    ?? c.req.header("x-real-ip")
-    ?? "127.0.0.1";
-
+  const ip = clientIp(c);
   const now = Date.now();
+  pruneBuckets(now);
+
   let bucket = buckets.get(ip);
 
   if (!bucket || bucket.resetAt <= now) {


### PR DESCRIPTION
Closes #3

Protects login, setup, and migration/import from brute-force attacks.

- Adds src/server/rate-limit.ts with simple in-memory sliding window rate limiter (10 req/min per IP)
- Applies rateLimit middleware to /api/auth/login, /api/auth/setup, and /api/auth/migration/import
- Returns 429 with rate-limit headers when exceeded

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add in-memory, bounded sliding-window rate limiting (10 req/min per IP) to `/api/auth/login`, `/api/auth/setup`, and `/api/auth/migration/import` to block brute-force attempts. Over-limit requests return 429 with `X-RateLimit-*` headers.

<sup>Written for commit cdba2bb0b516ebde24165ce69398306c3d027de8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/xt42io/aeroplane/pull/4?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

