### PR TITLE
Add one-click GitHub connection via App Manifest flow

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -43,7 +43,7 @@
       "devDependencies": {
         "@tanstack/router-plugin": "^1.168.13",
         "@types/better-sqlite3": "^7.6.13",
-        "@types/node": "^25.9.1",
+        "@types/node": "^25.9.3",
         "@types/react": "^19.2.15",
         "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react": "^6.0.2",
@@ -263,7 +263,6 @@
       "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
         "@babel/generator": "^7.29.7",
@@ -645,7 +644,6 @@
       "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.43.0.tgz",
       "integrity": "sha512-V7ZCLQO3Jus9hzh2jVCCPW3mO4IBMr43O37PqSUYautJSnnJF41YlgLw21x0fLJTYvJ+Vkm6Gp+qKGH9pltgXA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@codemirror/state": "^6.6.0",
         "crelt": "^1.0.6",
@@ -1236,7 +1234,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
       "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -1839,7 +1836,6 @@
       "resolved": "https://registry.npmjs.org/@tanstack/react-router/-/react-router-1.170.10.tgz",
       "integrity": "sha512-gVmWYq0ucWr+OB97Nud0YhKa9NOipB7/QrWI7wRZJJWEL0qUS8WPqAs0vA1f3IBXZpXmf8xxzf/tl5cmo4tlmA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@tanstack/history": "1.162.0",
         "@tanstack/react-store": "^0.9.3",
@@ -1908,7 +1904,6 @@
       "resolved": "https://registry.npmjs.org/@tanstack/router-core/-/router-core-1.171.8.tgz",
       "integrity": "sha512-PbrTBbofFcacrH3RLgHYILRqTFnAGq+gXrXoA/vo7qUSkJpSO4GWfLtrtCahD4VayzRm19IPwcjPPLEugag6pw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@tanstack/history": "1.162.0",
         "cookie-es": "^3.0.0",
@@ -2091,15 +2086,14 @@
       "integrity": "sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/node": "*"
       }
     },
     "node_modules/@types/node": {
-      "version": "25.9.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.1.tgz",
-      "integrity": "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==",
+      "version": "25.9.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.3.tgz",
+      "integrity": "sha512-603BddQMv3pUcr4U2dhujk83N2tTDVr/34wII2B6bJy6g+8WD6yUb11jszNs0gdi4PesVWl7ABt8nYMVpnLUcg==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
@@ -2112,7 +2106,6 @@
       "integrity": "sha512-eRwcGNHve+E8qtEQSSRl6urh+rFop4v8gm6O8rGv25CodbvFdLjA1vVQ1KkiFE0w0UPOnb8tDiFKL5lp0rtY5Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -2321,7 +2314,6 @@
       "integrity": "sha512-CyzaZRQKyHkB2ZInfTTl2nvT33EbDpjkLEbE8/Zck3Ll6O0qqvuGdrJ45HgtH+HykRg88ITY3AdreBGN70aBSQ==",
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "bindings": "^1.5.0",
         "prebuild-install": "^7.1.1"
@@ -2370,7 +2362,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -2589,8 +2580,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/debug": {
       "version": "4.4.3",
@@ -2983,7 +2973,6 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.21.tgz",
       "integrity": "sha512-uV63apnb0kyPtAUwoWgaGh9HyIFcv8lgmzPZSiTBQAFOFGIzka5EZ1dZocmGnn0XdX0+XTqJ6Tqv7selMuGLRQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -3588,7 +3577,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.6.tgz",
       "integrity": "sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3598,7 +3586,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.6.tgz",
       "integrity": "sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -3730,7 +3717,6 @@
       "resolved": "https://registry.npmjs.org/seroval/-/seroval-1.5.4.tgz",
       "integrity": "sha512-46uFvgrXTVxZcUorgSSRZ4y+ieqLLQRMlG4bnCZKW3qI6BZm7Rg4ntMW4p1mILEEBZWrFlcpp0AyIIlM6jD9iw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -3968,7 +3954,6 @@
       "integrity": "sha512-mdoNxBC/cSQObGGVQ5Bpn5i+yv7j68gk3Nfm3wFjcJg3Z0Mix9jzAFfP12prmm5eVGmDKtp0yyArrs0Q+8gZHg==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "~0.28.0"
       },
@@ -4081,7 +4066,6 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.13.tgz",
       "integrity": "sha512-MFtjBYgzmSxmgA4RAfjIyXWpGe1oALnjgUTzzV7QLx/TKxCzjtMH6Fd9/eVK+5Fg1qNoz5VAwsmMs/NofrmJvw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -4242,7 +4226,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
       "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
   "devDependencies": {
     "@tanstack/router-plugin": "^1.168.13",
     "@types/better-sqlite3": "^7.6.13",
-    "@types/node": "^25.9.1",
+    "@types/node": "^25.9.3",
     "@types/react": "^19.2.15",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.2",

--- a/src/client/api.ts
+++ b/src/client/api.ts
@@ -918,6 +918,11 @@ export const api = {
     }),
   disconnectAiProvider: (providerId: AiProviderId) =>
     request<{ ok: boolean; ai: AiSettingsStatus }>(`/api/system/ai/providers/${providerId}`, { method: "DELETE" }),
+  githubManifest: (body: { redirectTo: "onboarding" | "settings"; organization?: string }) =>
+    request<{ postUrl: string; manifest: string }>("/api/github/manifest", {
+      method: "POST",
+      body: JSON.stringify(body)
+    }),
   githubSettings: () => request<GitHubSettingsStatus>("/api/system/github"),
   updateGithubSettings: (body: {
     githubAccessToken?: string;

--- a/src/client/components/modals/github-settings-panel.tsx
+++ b/src/client/components/modals/github-settings-panel.tsx
@@ -8,6 +8,7 @@ import {
 } from "@hugeicons/core-free-icons";
 import { FormEvent, useEffect, useState } from "react";
 import { api, type GitHubSettingsStatus } from "../../api";
+import { startGitHubAppManifestFlow } from "../../lib/github-app-manifest";
 import { AppIcon, FieldLabel, FormInput, shellButton, statusClass } from "../ui/primitives";
 
 type GitHubFormState = {
@@ -63,6 +64,7 @@ export function GitHubSettingsPanel({ open }: { open: boolean }) {
   const [editing, setEditing] = useState(false);
   const [disconnecting, setDisconnecting] = useState(false);
   const [busy, setBusy] = useState(false);
+  const [connecting, setConnecting] = useState(false);
   const [success, setSuccess] = useState("");
   const [error, setError] = useState("");
 
@@ -117,6 +119,30 @@ export function GitHubSettingsPanel({ open }: { open: boolean }) {
       setError(issue instanceof Error ? issue.message : "Could not save GitHub settings");
     } finally {
       setBusy(false);
+    }
+  }
+
+  async function connectOneClick() {
+    setConnecting(true);
+    setError("");
+    setSuccess("");
+
+    try {
+      const result = await startGitHubAppManifestFlow({ redirectTo: "settings" });
+      if (!result.ok) {
+        setError(result.message);
+        return;
+      }
+      const refreshed = await api.githubSettings();
+      setGithub(refreshed);
+      setForm(formFromSettings(refreshed));
+      setEditing(false);
+      setDisconnecting(false);
+      setSuccess("GitHub App created and connected. Install it on your repositories to finish.");
+    } catch (issue) {
+      setError(issue instanceof Error ? issue.message : "Could not connect to GitHub");
+    } finally {
+      setConnecting(false);
     }
   }
 
@@ -238,6 +264,23 @@ export function GitHubSettingsPanel({ open }: { open: boolean }) {
               <AppIcon icon={LinkSquare02Icon} size={14} />
               Create GitHub App
             </a>
+          </div>
+
+          <div className="flex flex-wrap items-center justify-between gap-3 border border-[#4FB8B2]/35 bg-[#4FB8B2]/10 px-4 py-3">
+            <div className="min-w-0">
+              <div className="font-mono text-[10px] uppercase tracking-[0.2em] text-[#7fe3dd]">One-click connect</div>
+              <div className="text-sm text-zinc-200">Create the GitHub App and fill in every credential automatically.</div>
+            </div>
+            <button type="button" onClick={() => void connectOneClick()} disabled={connecting || busy} className={shellButton("primary")}>
+              <AppIcon icon={GithubIcon} size={15} />
+              {connecting ? "Connecting…" : "Connect with GitHub"}
+            </button>
+          </div>
+
+          <div className="flex items-center gap-3 font-mono text-[10px] uppercase tracking-[0.2em] text-zinc-600">
+            <span className="h-px flex-1 bg-zinc-800" />
+            or enter manually
+            <span className="h-px flex-1 bg-zinc-800" />
           </div>
 
           <div className="grid gap-4 md:grid-cols-2">

--- a/src/client/features/github/github-install-modal.tsx
+++ b/src/client/features/github/github-install-modal.tsx
@@ -26,7 +26,7 @@ export function GitHubInstallModal({
       width="max-w-2xl"
     >
       <div className="space-y-5">
-        <div className="rounded-xl border border-neutral-200 bg-neutral-50 p-4 text-sm leading-6 text-neutral-600">
+        <div className="border border-zinc-800 bg-zinc-950/70 px-4 py-3 text-sm leading-6 text-zinc-300">
           The server is configured, but the GitHub App is not installed on any repositories yet. Install it once, then new services can browse repos, pick branches, and choose deployment directories directly.
         </div>
         <div className="flex justify-end">

--- a/src/client/features/onboarding/github-step.tsx
+++ b/src/client/features/onboarding/github-step.tsx
@@ -1,5 +1,7 @@
-import { GithubIcon, LinkSquare02Icon } from "@hugeicons/core-free-icons";
+import { CheckmarkCircle02Icon, GithubIcon, LinkSquare02Icon } from "@hugeicons/core-free-icons";
+import { useState } from "react";
 import { AppIcon } from "../../components/ui/primitives";
+import { startGitHubAppManifestFlow } from "../../lib/github-app-manifest";
 import type { OnboardingForm } from "./onboarding-types";
 import { OnboardingSection, TextAreaField, TextField } from "./onboarding-fields";
 
@@ -10,48 +12,101 @@ export function GitHubStep({
   form: OnboardingForm;
   update: (patch: Partial<OnboardingForm>) => void;
 }) {
+  const [manualOpen, setManualOpen] = useState(false);
+  const [connecting, setConnecting] = useState(false);
+  const [connected, setConnected] = useState(false);
+  const [error, setError] = useState("");
+
+  async function connect() {
+    setConnecting(true);
+    setError("");
+    try {
+      const result = await startGitHubAppManifestFlow({ redirectTo: "onboarding" });
+      if (result.ok) {
+        setConnected(true);
+      } else {
+        setError(result.message);
+      }
+    } catch (issue) {
+      setError(issue instanceof Error ? issue.message : "Could not connect to GitHub");
+    } finally {
+      setConnecting(false);
+    }
+  }
+
   return (
     <OnboardingSection
       eyebrow="Step 03"
       title="GitHub integration"
-      description="These are optional. You can start with a token, or leave this blank and configure the GitHub App from system settings later."
+      description="Optional. Connect in one click to create and install a GitHub App automatically, or skip this and configure it from system settings later."
     >
-      <div className="mb-5 flex flex-wrap items-center justify-between gap-3 border border-zinc-800 bg-zinc-950/70 px-4 py-3">
-        <div className="flex min-w-0 items-center gap-3">
-          <div className="grid h-9 w-9 place-items-center border border-zinc-700 bg-zinc-900 text-zinc-300">
-            <AppIcon icon={GithubIcon} size={16} />
+      {connected ? (
+        <div className="mb-5 flex items-center gap-3 border border-emerald-500/35 bg-emerald-950/25 px-4 py-3 text-sm text-emerald-200">
+          <AppIcon icon={CheckmarkCircle02Icon} size={16} />
+          GitHub App created and connected. Finish setup, then install it on your repositories from system settings.
+        </div>
+      ) : (
+        <div className="mb-5 flex flex-wrap items-center justify-between gap-3 border border-zinc-800 bg-zinc-950/70 px-4 py-3">
+          <div className="flex min-w-0 items-center gap-3">
+            <div className="grid h-9 w-9 place-items-center border border-zinc-700 bg-zinc-900 text-zinc-300">
+              <AppIcon icon={GithubIcon} size={16} />
+            </div>
+            <div className="min-w-0">
+              <div className="font-mono text-[10px] uppercase tracking-[0.2em] text-zinc-500">One-click connect</div>
+              <div className="text-sm text-zinc-200">We create the GitHub App and fill in every credential for you.</div>
+            </div>
           </div>
-          <div className="min-w-0">
-            <div className="font-mono text-[10px] uppercase tracking-[0.2em] text-zinc-500">Need an app?</div>
-            <div className="text-sm text-zinc-200">Create a GitHub App, then paste its credentials here.</div>
+          <button
+            type="button"
+            onClick={() => void connect()}
+            disabled={connecting}
+            className="inline-flex h-9 items-center justify-center gap-2 border border-[#4FB8B2]/45 bg-[#4FB8B2]/12 px-3 font-mono text-[10px] font-semibold uppercase tracking-[0.18em] text-[#9af4ee] transition hover:bg-[#4FB8B2]/20 disabled:opacity-60"
+          >
+            <AppIcon icon={GithubIcon} size={14} />
+            {connecting ? "Connecting…" : "Connect GitHub"}
+          </button>
+        </div>
+      )}
+
+      {error ? (
+        <div className="mb-5 border border-rose-500/35 bg-rose-950/30 px-3.5 py-2.5 font-mono text-[10px] text-rose-300">{error}</div>
+      ) : null}
+
+      <button
+        type="button"
+        onClick={() => setManualOpen((open) => !open)}
+        className="inline-flex items-center gap-2 font-mono text-[10px] font-semibold uppercase tracking-[0.18em] text-zinc-400 transition hover:text-zinc-200"
+      >
+        <AppIcon icon={LinkSquare02Icon} size={13} />
+        {manualOpen ? "Hide manual setup" : "Enter credentials manually"}
+      </button>
+
+      {manualOpen ? (
+        <div className="mt-4 grid gap-4 md:grid-cols-2">
+          <TextField label="GITHUB_ACCESS_TOKEN" value={form.githubAccessToken} onChange={(githubAccessToken) => update({ githubAccessToken })} type="password" />
+          <TextField label="GITHUB_WEBHOOK_SECRET" value={form.githubWebhookSecret} onChange={(githubWebhookSecret) => update({ githubWebhookSecret })} type="password" />
+          <TextField label="GITHUB_APP_ID" value={form.githubAppId} onChange={(githubAppId) => update({ githubAppId })} />
+          <TextField label="GITHUB_APP_CLIENT_ID" value={form.githubAppClientId} onChange={(githubAppClientId) => update({ githubAppClientId })} />
+          <TextField label="GITHUB_APP_SLUG" value={form.githubAppSlug} onChange={(githubAppSlug) => update({ githubAppSlug })} />
+          <a
+            href="https://github.com/settings/apps/new"
+            target="_blank"
+            rel="noreferrer"
+            className="inline-flex h-9 items-center justify-center gap-2 self-end border border-zinc-700 bg-zinc-900 px-3 font-mono text-[10px] font-semibold uppercase tracking-[0.18em] text-zinc-300 transition hover:border-[#4FB8B2]/45 hover:text-[#9af4ee]"
+          >
+            <AppIcon icon={LinkSquare02Icon} size={14} />
+            Create GitHub App
+          </a>
+          <div className="md:col-span-2">
+            <TextAreaField
+              label="GITHUB_APP_PRIVATE_KEY"
+              value={form.githubAppPrivateKey}
+              onChange={(githubAppPrivateKey) => update({ githubAppPrivateKey })}
+              placeholder="-----BEGIN PRIVATE KEY-----"
+            />
           </div>
         </div>
-        <a
-          href="https://github.com/settings/apps/new"
-          target="_blank"
-          rel="noreferrer"
-          className="inline-flex h-9 items-center justify-center gap-2 border border-[#4FB8B2]/45 bg-[#4FB8B2]/12 px-3 font-mono text-[10px] font-semibold uppercase tracking-[0.18em] text-[#9af4ee] transition hover:bg-[#4FB8B2]/20"
-        >
-          <AppIcon icon={LinkSquare02Icon} size={14} />
-          Create GitHub App
-        </a>
-      </div>
-      <div className="grid gap-4 md:grid-cols-2">
-        <TextField label="GITHUB_ACCESS_TOKEN" value={form.githubAccessToken} onChange={(githubAccessToken) => update({ githubAccessToken })} type="password" />
-        <TextField label="GITHUB_WEBHOOK_SECRET" value={form.githubWebhookSecret} onChange={(githubWebhookSecret) => update({ githubWebhookSecret })} type="password" />
-        <TextField label="GITHUB_APP_ID" value={form.githubAppId} onChange={(githubAppId) => update({ githubAppId })} />
-        <TextField label="GITHUB_APP_CLIENT_ID" value={form.githubAppClientId} onChange={(githubAppClientId) => update({ githubAppClientId })} />
-        <TextField label="GITHUB_APP_SLUG" value={form.githubAppSlug} onChange={(githubAppSlug) => update({ githubAppSlug })} />
-        <div />
-        <div className="md:col-span-2">
-          <TextAreaField
-            label="GITHUB_APP_PRIVATE_KEY"
-            value={form.githubAppPrivateKey}
-            onChange={(githubAppPrivateKey) => update({ githubAppPrivateKey })}
-            placeholder="-----BEGIN PRIVATE KEY-----"
-          />
-        </div>
-      </div>
+      ) : null}
     </OnboardingSection>
   );
 }

--- a/src/client/lib/github-app-manifest.ts
+++ b/src/client/lib/github-app-manifest.ts
@@ -1,0 +1,80 @@
+import { api } from "../api";
+
+type ManifestMessage = {
+  source: "aeroplane-github-manifest";
+  ok: boolean;
+  message: string;
+};
+
+function isManifestMessage(data: unknown): data is ManifestMessage {
+  return Boolean(data) && typeof data === "object" && (data as ManifestMessage).source === "aeroplane-github-manifest";
+}
+
+/**
+ * Drives GitHub's App Manifest "one-click" flow. Opens a popup, POSTs a
+ * pre-filled App manifest to GitHub, and resolves once GitHub redirects the
+ * popup back to our callback (which posts a message and closes itself).
+ *
+ * Using a popup keeps the current page — e.g. an in-progress onboarding form —
+ * intact instead of navigating away from it.
+ */
+export async function startGitHubAppManifestFlow(options: {
+  redirectTo: "onboarding" | "settings";
+  organization?: string;
+}): Promise<{ ok: boolean; message: string }> {
+  const popup = window.open("", "aeroplane-github-app", "width=1024,height=768,menubar=no,toolbar=no");
+  if (!popup) {
+    throw new Error("Could not open the GitHub window. Allow pop-ups for this site and try again.");
+  }
+  popup.document.write("Connecting to GitHub…");
+
+  let manifest: { postUrl: string; manifest: string };
+  try {
+    manifest = await api.githubManifest({ redirectTo: options.redirectTo, organization: options.organization });
+  } catch (error) {
+    popup.close();
+    throw error;
+  }
+
+  const form = document.createElement("form");
+  form.method = "POST";
+  form.action = manifest.postUrl;
+  form.target = "aeroplane-github-app";
+  form.style.display = "none";
+
+  const input = document.createElement("input");
+  input.type = "hidden";
+  input.name = "manifest";
+  input.value = manifest.manifest;
+  form.appendChild(input);
+
+  document.body.appendChild(form);
+  form.submit();
+  form.remove();
+
+  return await new Promise((resolve, reject) => {
+    let settled = false;
+
+    const cleanup = () => {
+      window.removeEventListener("message", onMessage);
+      window.clearInterval(closedTimer);
+    };
+
+    const onMessage = (event: MessageEvent) => {
+      if (event.origin !== window.location.origin || !isManifestMessage(event.data)) return;
+      settled = true;
+      cleanup();
+      resolve({ ok: event.data.ok, message: event.data.message });
+    };
+
+    // The popup may be closed by the user before completing the flow.
+    const closedTimer = window.setInterval(() => {
+      if (popup.closed && !settled) {
+        cleanup();
+        reject(new Error("GitHub connection was cancelled."));
+      }
+    }, 600);
+
+    window.addEventListener("message", onMessage);
+  });
+}

--- a/src/server/github-connect.ts
+++ b/src/server/github-connect.ts
@@ -424,21 +424,44 @@ export type GitHubAppCredentials = {
   owner: string;
 };
 
+function isPublicWebhookHost(baseUrl: string) {
+  try {
+    const hostname = new URL(baseUrl).hostname.toLowerCase();
+    return !(
+      hostname === "localhost" ||
+      hostname === "127.0.0.1" ||
+      hostname === "::1" ||
+      hostname.endsWith(".localhost") ||
+      hostname.startsWith("10.") ||
+      hostname.startsWith("192.168.") ||
+      /^172\.(1[6-9]|2\d|3[0-1])\./.test(hostname)
+    );
+  } catch {
+    return false;
+  }
+}
+
 export function buildGitHubAppManifest(options: { baseUrl: string; name: string }) {
   const base = options.baseUrl.replace(/\/+$/, "");
-  return {
+  const manifest = {
     name: options.name,
     url: base,
     redirect_url: `${base}/api/github/manifest/callback`,
-    hook_attributes: {
-      url: `${base}/api/github/app/webhook`,
-      active: true
-    },
     public: false,
     default_permissions: {
       contents: "read",
       metadata: "read",
       pull_requests: "read"
+    }
+  };
+
+  if (!isPublicWebhookHost(base)) return manifest;
+
+  return {
+    ...manifest,
+    hook_attributes: {
+      url: `${base}/api/github/app/webhook`,
+      active: true
     },
     default_events: ["push"]
   };

--- a/src/server/github-connect.ts
+++ b/src/server/github-connect.ts
@@ -402,6 +402,79 @@ async function getAppInstallationCount() {
   return installations.length;
 }
 
+type GitHubManifestConversion = {
+  id: number;
+  slug: string;
+  client_id: string;
+  client_secret: null | string;
+  webhook_secret: null | string;
+  pem: string;
+  html_url: string;
+  owner: { login: string };
+};
+
+export type GitHubAppCredentials = {
+  appId: string;
+  slug: string;
+  clientId: string;
+  clientSecret: string;
+  webhookSecret: string;
+  privateKey: string;
+  htmlUrl: string;
+  owner: string;
+};
+
+export function buildGitHubAppManifest(options: { baseUrl: string; name: string }) {
+  const base = options.baseUrl.replace(/\/+$/, "");
+  return {
+    name: options.name,
+    url: base,
+    redirect_url: `${base}/api/github/manifest/callback`,
+    hook_attributes: {
+      url: `${base}/api/github/app/webhook`,
+      active: true
+    },
+    public: false,
+    default_permissions: {
+      contents: "read",
+      metadata: "read",
+      pull_requests: "read"
+    },
+    default_events: ["push"]
+  };
+}
+
+// Exchanges the temporary code GitHub sends back after an App Manifest creation for
+// the full set of App credentials. This endpoint takes no authentication — the
+// single-use code is the credential.
+export async function convertGitHubManifestCode(code: string): Promise<GitHubAppCredentials> {
+  const response = await fetch(`https://api.github.com/app-manifests/${encodeURIComponent(code)}/conversions`, {
+    method: "POST",
+    headers: {
+      Accept: "application/vnd.github+json",
+      "User-Agent": "aeroplane-control-plane",
+      "X-GitHub-Api-Version": "2022-11-28"
+    }
+  });
+
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(`GitHub manifest conversion failed (${response.status}): ${body || response.statusText}`);
+  }
+
+  const data = (await response.json()) as GitHubManifestConversion;
+  return {
+    appId: String(data.id),
+    slug: data.slug,
+    clientId: data.client_id,
+    clientSecret: data.client_secret ?? "",
+    webhookSecret: data.webhook_secret ?? "",
+    privateKey: data.pem ?? "",
+    htmlUrl: data.html_url,
+    owner: data.owner?.login ?? ""
+  };
+}
+
 export async function githubConnectionStatus(): Promise<GitHubStatus> {
   if (hasGitHubAppConfig()) {
     const installationCount = await getAppInstallationCount();

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -1343,6 +1343,7 @@ app.get("/api/assets/framework-icons/:file", async (c) => {
 type GitHubManifestState = { expiresAt: number; redirectTo: string };
 const githubManifestStates = new Map<string, GitHubManifestState>();
 const githubManifestStateTtl = 15 * 60 * 1000;
+const githubManifestStateLimit = 500;
 
 function requestBaseUrl(c: Context) {
   const requestUrl = new URL(c.req.url);
@@ -1355,6 +1356,11 @@ function createGitHubManifestState(redirectTo: string) {
   const now = Date.now();
   for (const [key, value] of githubManifestStates) {
     if (value.expiresAt <= now) githubManifestStates.delete(key);
+  }
+  while (githubManifestStates.size >= githubManifestStateLimit) {
+    const oldestState = githubManifestStates.keys().next().value;
+    if (!oldestState) break;
+    githubManifestStates.delete(oldestState);
   }
   const state = randomBytes(24).toString("hex");
   githubManifestStates.set(state, { expiresAt: now + githubManifestStateTtl, redirectTo });
@@ -1401,8 +1407,13 @@ function renderManifestCallbackPage(ok: boolean, message: string) {
 </body></html>`;
 }
 
+function canUseGitHubManifest(c: Context) {
+  if (!hasAuthUsers()) return true;
+  return getCurrentUser(c)?.role === "owner";
+}
+
 app.post("/api/github/manifest", async (c) => {
-  if (hasAuthUsers() && !isOwnerSession(c)) {
+  if (!canUseGitHubManifest(c)) {
     return jsonError("Only the owner can connect GitHub", 403);
   }
 
@@ -1427,7 +1438,7 @@ app.get("/api/github/manifest/callback", async (c) => {
   if (!entry) {
     return c.html(renderManifestCallbackPage(false, "This GitHub connection link has expired. Please start again."));
   }
-  if (hasAuthUsers() && !isOwnerSession(c)) {
+  if (!canUseGitHubManifest(c)) {
     return c.html(renderManifestCallbackPage(false, "Only the owner can connect GitHub."));
   }
   if (!code) {

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -27,7 +27,7 @@ import { envExampleVariableSuggestions } from "./env-example-suggestions.js";
 import { resolveServiceEnv } from "./variable-resolver.js";
 import { getRailwayProjects, getRailwayProjectDetails, importRailwayProject } from "./railway-importer.js";
 import { startRailwayImportAutomation } from "./railway-import-automation.js";
-import { githubConnectionStatus, listConnectedRepos, listRepoBranches, listRepoDirectories, repoUrlFromFullName } from "./github-connect.js";
+import { buildGitHubAppManifest, convertGitHubManifestCode, githubConnectionStatus, listConnectedRepos, listRepoBranches, listRepoDirectories, repoUrlFromFullName } from "./github-connect.js";
 import { branchFromGitRef, verifyGitHubSignature } from "./github.js";
 import { subscribeToDeploymentLogs } from "./logBus.js";
 import {
@@ -1335,6 +1335,128 @@ app.get("/api/assets/framework-icons/:file", async (c) => {
       "Content-Type": asset.contentType
     }
   });
+});
+
+// --- GitHub App Manifest (one-click connect) ---
+// Registered before requireAuth so the flow works during first-run onboarding
+// (no users yet). Post-setup access is gated to the owner inside each handler.
+type GitHubManifestState = { expiresAt: number; redirectTo: string };
+const githubManifestStates = new Map<string, GitHubManifestState>();
+const githubManifestStateTtl = 15 * 60 * 1000;
+
+function requestBaseUrl(c: Context) {
+  const requestUrl = new URL(c.req.url);
+  const host = c.req.header("x-forwarded-host") ?? c.req.header("host") ?? requestUrl.host;
+  const proto = c.req.header("x-forwarded-proto")?.split(",")[0]?.trim() || requestUrl.protocol.replace(":", "");
+  return `${proto}://${host}`;
+}
+
+function createGitHubManifestState(redirectTo: string) {
+  const now = Date.now();
+  for (const [key, value] of githubManifestStates) {
+    if (value.expiresAt <= now) githubManifestStates.delete(key);
+  }
+  const state = randomBytes(24).toString("hex");
+  githubManifestStates.set(state, { expiresAt: now + githubManifestStateTtl, redirectTo });
+  return state;
+}
+
+function consumeGitHubManifestState(state: string) {
+  const entry = githubManifestStates.get(state);
+  if (!entry) return null;
+  githubManifestStates.delete(state);
+  if (entry.expiresAt <= Date.now()) return null;
+  return entry;
+}
+
+function defaultGitHubAppName(baseUrl: string) {
+  let hostSlug = "";
+  try {
+    hostSlug = new URL(baseUrl).hostname.replace(/[^a-z0-9]+/gi, "-").replace(/^-+|-+$/g, "").toLowerCase();
+  } catch {
+    hostSlug = "";
+  }
+  const stem = hostSlug && hostSlug !== "localhost" ? `aeroplane-${hostSlug}` : "aeroplane";
+  return `${stem}-${randomBytes(3).toString("hex")}`.slice(0, 34);
+}
+
+function escapeHtml(value: string) {
+  return value.replace(/[&<>"']/g, (ch) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" })[ch] ?? ch);
+}
+
+function renderManifestCallbackPage(ok: boolean, message: string) {
+  const payload = JSON.stringify({ source: "aeroplane-github-manifest", ok, message }).replace(/</g, "\\u003c");
+  return `<!doctype html><html><head><meta charset="utf-8"><title>GitHub connection</title></head>
+<body style="font-family:ui-monospace,SFMono-Regular,monospace;background:#09090b;color:#e4e4e7;display:grid;place-items:center;height:100vh;margin:0">
+<div style="text-align:center;max-width:32rem;padding:1.5rem">
+<p style="font-weight:600;color:${ok ? "#34d399" : "#fb7185"}">${ok ? "&#10003; Connected" : "&#10007; Connection failed"}</p>
+<p style="color:#a1a1aa">${escapeHtml(message)}</p>
+</div>
+<script>
+(function(){
+  try { if (window.opener) window.opener.postMessage(${payload}, window.location.origin); } catch (e) {}
+  setTimeout(function(){ try { window.close(); } catch (e) {} }, ${ok ? 800 : 4000});
+})();
+</script>
+</body></html>`;
+}
+
+app.post("/api/github/manifest", async (c) => {
+  if (hasAuthUsers() && !isOwnerSession(c)) {
+    return jsonError("Only the owner can connect GitHub", 403);
+  }
+
+  const body = (await c.req.json().catch(() => ({}))) as { organization?: unknown; redirectTo?: unknown };
+  const redirectTo = body.redirectTo === "onboarding" ? "onboarding" : "settings";
+  const organization = typeof body.organization === "string" ? body.organization.trim() : "";
+  const baseUrl = requestBaseUrl(c);
+  const state = createGitHubManifestState(redirectTo);
+  const manifest = buildGitHubAppManifest({ baseUrl, name: defaultGitHubAppName(baseUrl) });
+  const postUrl = organization
+    ? `https://github.com/organizations/${encodeURIComponent(organization)}/settings/apps/new?state=${state}`
+    : `https://github.com/settings/apps/new?state=${state}`;
+
+  return c.json({ postUrl, manifest: JSON.stringify(manifest) });
+});
+
+app.get("/api/github/manifest/callback", async (c) => {
+  const code = c.req.query("code") ?? "";
+  const state = c.req.query("state") ?? "";
+  const entry = state ? consumeGitHubManifestState(state) : null;
+
+  if (!entry) {
+    return c.html(renderManifestCallbackPage(false, "This GitHub connection link has expired. Please start again."));
+  }
+  if (hasAuthUsers() && !isOwnerSession(c)) {
+    return c.html(renderManifestCallbackPage(false, "Only the owner can connect GitHub."));
+  }
+  if (!code) {
+    return c.html(renderManifestCallbackPage(false, "GitHub did not return an authorization code."));
+  }
+
+  try {
+    const credentials = await convertGitHubManifestCode(code);
+    const existing = currentGithubEnv();
+    const next = {
+      githubAccessToken: existing.githubAccessToken,
+      githubAppId: credentials.appId,
+      githubAppClientId: credentials.clientId,
+      githubAppSlug: credentials.slug,
+      githubAppPrivateKey: credentials.privateKey,
+      githubWebhookSecret: credentials.webhookSecret
+    };
+    writeManagedEnvPatch({
+      GITHUB_APP_ID: next.githubAppId,
+      GITHUB_APP_CLIENT_ID: next.githubAppClientId,
+      GITHUB_APP_SLUG: next.githubAppSlug,
+      GITHUB_APP_PRIVATE_KEY: next.githubAppPrivateKey,
+      GITHUB_WEBHOOK_SECRET: next.githubWebhookSecret
+    });
+    updateGithubRuntimeEnv(next);
+    return c.html(renderManifestCallbackPage(true, "GitHub App created and connected. You can close this window."));
+  } catch (error) {
+    return c.html(renderManifestCallbackPage(false, error instanceof Error ? error.message : "Could not complete GitHub connection."));
+  }
 });
 
 app.use("/api/*", requireAuth);


### PR DESCRIPTION
## Summary

During VPS/dashboard setup, connecting GitHub currently requires manually creating a GitHub App and copy-pasting six credentials (App ID, Client ID, slug, private key, webhook secret, plus an optional PAT) — error-prone, especially the multi-line private key.

This PR adds a **one-click connection** using GitHub's [App Manifest flow](https://docs.github.com/en/apps/sharing-github-apps/registering-a-github-app-from-a-manifest) — the same mechanism Coolify and Dokploy use. The user clicks one button, picks an account/org on GitHub, clicks **Create**, and every credential is generated and persisted automatically. Manual entry is kept as a fallback.

## How it works

1. The client requests a pre-filled App manifest from the server and submits it to GitHub in a popup (the popup keeps an in-progress onboarding form intact).
2. The user creates the App on GitHub with one click.
3. GitHub redirects the popup back to our callback with a one-time `code`.
4. The server exchanges the code at `POST /app-manifests/{code}/conversions`, receiving the App ID, slug, client ID, private key (`pem`), and webhook secret.
5. Credentials are persisted through the existing managed-env path, and the popup posts a message back and closes.

The user then installs the App on their repositories via the existing "Install GitHub App" link.

## Changes

**Server**
- `src/server/github-connect.ts` — `buildGitHubAppManifest()` (name, redirect URL, webhook URL, permissions `contents`/`metadata`/`pull_requests: read`, `push` event) and `convertGitHubManifestCode()` (no-auth code exchange).
- `src/server/index.ts` — `POST /api/github/manifest` and `GET /api/github/manifest/callback`. Registered **before** `requireAuth` so the flow works during first-run onboarding (no users yet), with an owner-only guard once setup is complete, and single-use, 15-minute CSRF `state` tokens.

**Client**
- `src/client/lib/github-app-manifest.ts` (new) — popup-based flow helper that submits the manifest to GitHub and resolves on the callback's `postMessage`.
- `src/client/api.ts` — `githubManifest()` API method.
- `src/client/features/onboarding/github-step.tsx` — one-click "Connect GitHub" button; manual fields collapsed behind "Enter credentials manually".
- `src/client/components/modals/github-settings-panel.tsx` — "Connect with GitHub" banner above the manual form, refreshing status on success.

## Design notes

- **Base URL** is derived from `x-forwarded-proto`/`x-forwarded-host` request headers, so the flow works behind the Caddy proxy without `PUBLIC_URL` being set first — important during onboarding.
- **Onboarding ordering is safe**: the callback writes credentials to `process.env`, and `applyOnboardingSettings` uses `?? process.env.GITHUB_*` (empty form fields become `undefined`), so finishing onboarding preserves — rather than wipes — the one-click credentials.
- **Manual entry retained** as a fallback for air-gapped/proxy-restricted setups.

## Caveats / testing

- The instance needs a browser-reachable URL (ideally HTTPS for webhook delivery) — the same constraint Coolify/Dokploy have.
- `npm run typecheck` and `vite build` both pass.
- The end-to-end GitHub round-trip wasn't tested locally since it requires a public callback URL and a real GitHub account; the manifest construction, code-exchange, persistence, and UI wiring are verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add one-click GitHub connection using the GitHub App Manifest flow to auto-create and persist all App credentials during onboarding and in settings. This removes manual copy/paste and speeds up setup.

- **New Features**
  - Server: `POST /api/github/manifest` and `GET /api/github/manifest/callback` are registered before auth for first-run onboarding; access is owner-only after setup. Uses single-use CSRF `state` tokens (15‑min TTL) with a capped in-memory store (500 entries). Base URL is derived from `x-forwarded-*` headers.
  - Manifest: redirects to our callback; sets webhook at `/api/github/app/webhook` and `push` event only when the host is public; permissions `contents`, `metadata`, `pull_requests: read`. Supports optional `organization` to create the App under an org.
  - Flow: popup-based `startGitHubAppManifestFlow()` posts a pre-filled manifest to GitHub, then the callback converts the code, writes credentials to managed env, updates runtime, and closes the popup.
  - UI: one-click “Connect GitHub” in onboarding and settings (with success/error states); manual fields moved behind “Enter credentials manually”; improved GitHub install modal styling.

- **Dependencies**
  - Bump `@types/node` to `^25.9.3`.

<sup>Written for commit a64efb6305710b931912b299b8552d9dda105574. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/xt42io/aeroplane/pull/6?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

