### PR TITLE
feat: implement import projects from vercel

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -263,7 +263,6 @@
       "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
         "@babel/generator": "^7.29.7",
@@ -645,7 +644,6 @@
       "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.43.0.tgz",
       "integrity": "sha512-V7ZCLQO3Jus9hzh2jVCCPW3mO4IBMr43O37PqSUYautJSnnJF41YlgLw21x0fLJTYvJ+Vkm6Gp+qKGH9pltgXA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@codemirror/state": "^6.6.0",
         "crelt": "^1.0.6",
@@ -1236,7 +1234,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
       "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -1839,7 +1836,6 @@
       "resolved": "https://registry.npmjs.org/@tanstack/react-router/-/react-router-1.170.10.tgz",
       "integrity": "sha512-gVmWYq0ucWr+OB97Nud0YhKa9NOipB7/QrWI7wRZJJWEL0qUS8WPqAs0vA1f3IBXZpXmf8xxzf/tl5cmo4tlmA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@tanstack/history": "1.162.0",
         "@tanstack/react-store": "^0.9.3",
@@ -1908,7 +1904,6 @@
       "resolved": "https://registry.npmjs.org/@tanstack/router-core/-/router-core-1.171.8.tgz",
       "integrity": "sha512-PbrTBbofFcacrH3RLgHYILRqTFnAGq+gXrXoA/vo7qUSkJpSO4GWfLtrtCahD4VayzRm19IPwcjPPLEugag6pw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@tanstack/history": "1.162.0",
         "cookie-es": "^3.0.0",
@@ -2091,7 +2086,6 @@
       "integrity": "sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/node": "*"
       }
@@ -2112,7 +2106,6 @@
       "integrity": "sha512-eRwcGNHve+E8qtEQSSRl6urh+rFop4v8gm6O8rGv25CodbvFdLjA1vVQ1KkiFE0w0UPOnb8tDiFKL5lp0rtY5Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -2321,7 +2314,6 @@
       "integrity": "sha512-CyzaZRQKyHkB2ZInfTTl2nvT33EbDpjkLEbE8/Zck3Ll6O0qqvuGdrJ45HgtH+HykRg88ITY3AdreBGN70aBSQ==",
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "bindings": "^1.5.0",
         "prebuild-install": "^7.1.1"
@@ -2370,7 +2362,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -2589,8 +2580,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/debug": {
       "version": "4.4.3",
@@ -2983,7 +2973,6 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.21.tgz",
       "integrity": "sha512-uV63apnb0kyPtAUwoWgaGh9HyIFcv8lgmzPZSiTBQAFOFGIzka5EZ1dZocmGnn0XdX0+XTqJ6Tqv7selMuGLRQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -3588,7 +3577,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.6.tgz",
       "integrity": "sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3598,7 +3586,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.6.tgz",
       "integrity": "sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -3730,7 +3717,6 @@
       "resolved": "https://registry.npmjs.org/seroval/-/seroval-1.5.4.tgz",
       "integrity": "sha512-46uFvgrXTVxZcUorgSSRZ4y+ieqLLQRMlG4bnCZKW3qI6BZm7Rg4ntMW4p1mILEEBZWrFlcpp0AyIIlM6jD9iw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -3968,7 +3954,6 @@
       "integrity": "sha512-mdoNxBC/cSQObGGVQ5Bpn5i+yv7j68gk3Nfm3wFjcJg3Z0Mix9jzAFfP12prmm5eVGmDKtp0yyArrs0Q+8gZHg==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "~0.28.0"
       },
@@ -4081,7 +4066,6 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.13.tgz",
       "integrity": "sha512-MFtjBYgzmSxmgA4RAfjIyXWpGe1oALnjgUTzzV7QLx/TKxCzjtMH6Fd9/eVK+5Fg1qNoz5VAwsmMs/NofrmJvw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -4242,7 +4226,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
       "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/client/api.ts
+++ b/src/client/api.ts
@@ -831,6 +831,54 @@ export const api = {
       method: "POST",
       body: JSON.stringify({ apiToken, projectId, config })
     }),
+  vercelTeams: (apiToken: string) =>
+    request<{ teams: Array<{ id: string; slug: string; name: string }> }>("/api/integrations/vercel/teams", {
+      method: "POST",
+      body: JSON.stringify({ apiToken })
+    }),
+  vercelProjects: (apiToken: string, teamId?: string) =>
+    request<{
+      projects: Array<{
+        id: string;
+        name: string;
+        framework: string | null;
+        kind: "git" | "unsupported";
+        sourceLabel: string;
+      }>;
+    }>("/api/integrations/vercel/projects", {
+      method: "POST",
+      body: JSON.stringify({ apiToken, teamId })
+    }),
+  vercelProjectDetails: (apiToken: string, projectId: string, teamId?: string) =>
+    request<{
+      details: {
+        id: string;
+        name: string;
+        framework: string | null;
+        rootDirectory: string | null;
+        buildCommand: string | null;
+        installCommand: string | null;
+        branch: string | null;
+        kind: "git" | "unsupported";
+        sourceLabel: string;
+        unsupportedReason: string | null;
+        targets: Array<"production" | "preview" | "development">;
+      };
+    }>("/api/integrations/vercel/project-details", {
+      method: "POST",
+      body: JSON.stringify({ apiToken, projectId, teamId })
+    }),
+  vercelImport: (apiToken: string, projectId: string, teamId: string | undefined, config?: unknown) =>
+    request<{
+      ok: boolean;
+      projectSlug: string;
+      importedCustomDomainCount?: number;
+      importedVariableCount?: number;
+      skippedSensitiveCount?: number;
+    }>("/api/integrations/vercel/import", {
+      method: "POST",
+      body: JSON.stringify({ apiToken, projectId, teamId, config })
+    }),
   systemSettings: () =>
     request<{
       settings: SystemSettings;

--- a/src/client/features/integrations/vercel-import-modal.tsx
+++ b/src/client/features/integrations/vercel-import-modal.tsx
@@ -1,0 +1,502 @@
+import { useState, useEffect } from "react";
+import {
+  Alert02Icon,
+  ArrowLeft01Icon,
+  CheckmarkCircle02Icon,
+  GithubIcon,
+  Search01Icon,
+  WorkflowSquare07Icon,
+  Globe02Icon,
+  Settings01Icon
+} from "@hugeicons/core-free-icons";
+import { useNavigate } from "@tanstack/react-router";
+import { api } from "../../api";
+import { ModalShell } from "../../components/modals/modal-shell";
+import { Checkbox } from "../../components/ui/checkbox";
+import { Dropdown } from "../../components/ui/dropdown";
+import { AppIcon, FieldLabel, FormInput, shellButton } from "../../components/ui/primitives";
+import { VercelMigrationOptions } from "./vercel-migration-options";
+
+interface VercelTeam {
+  id: string;
+  slug: string;
+  name: string;
+}
+
+interface VercelProject {
+  id: string;
+  name: string;
+  framework: string | null;
+  kind: "git" | "unsupported";
+  sourceLabel: string;
+}
+
+type VercelEnvTarget = "production" | "preview" | "development";
+
+interface VercelProjectDetails {
+  id: string;
+  name: string;
+  framework: string | null;
+  rootDirectory: string | null;
+  buildCommand: string | null;
+  installCommand: string | null;
+  branch: string | null;
+  kind: "git" | "unsupported";
+  sourceLabel: string;
+  unsupportedReason: string | null;
+  targets: VercelEnvTarget[];
+}
+
+interface VercelImportModalProps {
+  open: boolean;
+  onClose: () => void;
+  onSuccess: () => void;
+}
+
+const PERSONAL_SCOPE = "";
+
+const targetLabel: Record<VercelEnvTarget, string> = {
+  production: "Production",
+  preview: "Preview",
+  development: "Development"
+};
+
+export function VercelImportModal({ open, onClose, onSuccess }: VercelImportModalProps) {
+  const navigate = useNavigate();
+  const [step, setStep] = useState<"auth" | "select" | "configure" | "importing" | "success">("auth");
+  const [apiToken, setApiToken] = useState("");
+  const [teams, setTeams] = useState<VercelTeam[]>([]);
+  const [scope, setScope] = useState<string>(PERSONAL_SCOPE);
+  const [projects, setProjects] = useState<VercelProject[]>([]);
+  const [searchQuery, setSearchQuery] = useState("");
+  const [selectedProject, setSelectedProject] = useState<VercelProject | null>(null);
+  const [projectDetails, setProjectDetails] = useState<VercelProjectDetails | null>(null);
+  const [importedSlug, setImportedSlug] = useState("");
+  const [rememberToken, setRememberToken] = useState(() => {
+    const saved = localStorage.getItem("vercel_remember_token");
+    return saved !== "false";
+  });
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState("");
+
+  const [target, setTarget] = useState<VercelEnvTarget>("production");
+  const [excludeSystemVars, setExcludeSystemVars] = useState(true);
+  const [autoDeploy, setAutoDeploy] = useState(true);
+
+  useEffect(() => {
+    if (open) {
+      const savedToken = localStorage.getItem("vercel_api_token");
+      if (savedToken) {
+        setApiToken(savedToken);
+      }
+    }
+  }, [open]);
+
+  const filteredProjects = projects.filter(
+    (p) =>
+      p.name.toLowerCase().includes(searchQuery.toLowerCase()) ||
+      p.sourceLabel.toLowerCase().includes(searchQuery.toLowerCase())
+  );
+
+  async function loadProjectsForScope(token: string, teamId: string) {
+    const data = await api.vercelProjects(token, teamId || undefined);
+    setProjects(data.projects);
+  }
+
+  async function handleConnect() {
+    if (!apiToken.trim()) return;
+    const token = apiToken.trim();
+    setBusy(true);
+    setError("");
+    try {
+      const teamData = await api.vercelTeams(token).catch(() => ({ teams: [] }));
+      await loadProjectsForScope(token, PERSONAL_SCOPE);
+      localStorage.setItem("vercel_remember_token", rememberToken ? "true" : "false");
+      if (rememberToken) {
+        localStorage.setItem("vercel_api_token", token);
+      } else {
+        localStorage.removeItem("vercel_api_token");
+      }
+      setTeams(teamData.teams);
+      setScope(PERSONAL_SCOPE);
+      setStep("select");
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Invalid Vercel API Token or connection failed");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function handleScopeChange(nextScope: string) {
+    setScope(nextScope);
+    setBusy(true);
+    setError("");
+    try {
+      await loadProjectsForScope(apiToken.trim(), nextScope);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to load Vercel projects");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function handleSelectProject(project: VercelProject) {
+    setSelectedProject(project);
+    setBusy(true);
+    setError("");
+    try {
+      const data = await api.vercelProjectDetails(apiToken.trim(), project.id, scope || undefined);
+      setProjectDetails(data.details);
+      setTarget(data.details.targets[0] ?? "production");
+      setExcludeSystemVars(true);
+      setAutoDeploy(true);
+      setStep("configure");
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to load project details");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function handleExecuteImport() {
+    if (!selectedProject) return;
+    setStep("importing");
+    setBusy(true);
+    setError("");
+    try {
+      const config = { target, excludeSystemVars, autoDeploy };
+      const result = await api.vercelImport(apiToken.trim(), selectedProject.id, scope || undefined, config);
+      setImportedSlug(result.projectSlug);
+      setStep("success");
+      onSuccess();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Migration failed");
+      setStep("configure");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  function handleClose() {
+    setStep("auth");
+    setApiToken("");
+    setTeams([]);
+    setScope(PERSONAL_SCOPE);
+    setProjects([]);
+    setSearchQuery("");
+    setSelectedProject(null);
+    setProjectDetails(null);
+    setImportedSlug("");
+    setError("");
+    setTarget("production");
+    setExcludeSystemVars(true);
+    setAutoDeploy(true);
+    onClose();
+  }
+
+  const modalIcon =
+    step === "auth"
+      ? Settings01Icon
+      : step === "select"
+      ? Search01Icon
+      : step === "configure"
+      ? Settings01Icon
+      : step === "importing"
+      ? WorkflowSquare07Icon
+      : CheckmarkCircle02Icon;
+
+  const isUnsupported = projectDetails?.kind === "unsupported";
+
+  return (
+    <ModalShell
+      open={open}
+      onClose={handleClose}
+      icon={modalIcon}
+      title="Import Project from Vercel"
+      meta={
+        step === "auth"
+          ? "Step 1: Authenticate"
+          : step === "select"
+          ? "Step 2: Choose Project"
+          : step === "configure"
+          ? "Step 3: Configure Migration"
+          : step === "importing"
+          ? "Migration In Progress"
+          : "Migration Complete"
+      }
+      width="max-w-xl"
+      bodyClassName="min-h-0 flex flex-1 flex-col overflow-hidden"
+    >
+      {step === "auth" && (
+        <div className="space-y-5">
+          <div className="text-sm text-zinc-300 leading-relaxed">
+            Migrate a Vercel project to your self-hosted Aeroplane control plane. The connected Git repository, build
+            commands, environment variables, and custom domains are imported. Builds then run through Railpack on your
+            own server.
+          </div>
+
+          <div>
+            <div className="flex justify-between items-center mb-2">
+              <FieldLabel>Vercel API Token</FieldLabel>
+              <a
+                href="https://vercel.com/account/tokens"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-[10px] font-mono text-zinc-200 hover:underline uppercase tracking-wider"
+              >
+                Get token →
+              </a>
+            </div>
+            <FormInput
+              type="password"
+              value={apiToken}
+              onChange={(e) => setApiToken(e.target.value)}
+              placeholder="vercel_..."
+              disabled={busy}
+              autoComplete="new-password"
+              required
+            />
+            <div className="mt-3">
+              <Checkbox
+                checked={rememberToken}
+                onChange={setRememberToken}
+                disabled={busy}
+                label="Remember my Vercel token"
+              >
+                <span className="font-mono text-xs uppercase tracking-wider text-zinc-400">
+                  Remember my Vercel token
+                </span>
+              </Checkbox>
+            </div>
+          </div>
+
+          {error && (
+            <div className="border border-rose-500/35 bg-rose-950/20 px-4 py-3 text-xs text-rose-300 font-mono">
+              {error}
+            </div>
+          )}
+
+          <div className="flex justify-end gap-3 border-t border-zinc-800 pt-4 mt-5">
+            <button type="button" className={shellButton("ghost")} onClick={handleClose} disabled={busy}>
+              Cancel
+            </button>
+            <button
+              type="button"
+              className="inline-flex items-center justify-center gap-2 border border-zinc-100/40 bg-zinc-100/10 px-4 py-2.5 font-mono text-[11px] font-semibold uppercase tracking-wider text-zinc-100 transition hover:bg-zinc-100/20 disabled:opacity-60"
+              onClick={handleConnect}
+              disabled={busy || !apiToken.trim()}
+            >
+              Connect to Vercel
+            </button>
+          </div>
+        </div>
+      )}
+
+      {step === "select" && (
+        <div className="flex flex-col min-h-full">
+          <div className="mb-4">
+            <FieldLabel>Scope</FieldLabel>
+            <Dropdown
+              value={scope}
+              onChange={handleScopeChange}
+              disabled={busy}
+              options={[
+                { value: PERSONAL_SCOPE, label: "Personal Account" },
+                ...teams.map((team) => ({ value: team.id, label: team.name }))
+              ]}
+            />
+          </div>
+
+          <div className="relative mb-4">
+            <AppIcon icon={Search01Icon} size={16} className="pointer-events-none absolute left-3 top-3 text-zinc-500" />
+            <FormInput
+              value={searchQuery}
+              onChange={(e) => setSearchQuery(e.target.value)}
+              placeholder="Search Vercel projects"
+              className="pl-10"
+            />
+          </div>
+
+          {error && (
+            <div className="border border-rose-500/35 bg-rose-950/20 px-4 py-3 text-xs text-rose-300 font-mono mb-4">
+              {error}
+            </div>
+          )}
+
+          <div className="overflow-hidden border border-zinc-700 bg-zinc-900/85 flex-1 min-h-0">
+            <div className="max-h-[300px] overflow-y-auto">
+              {filteredProjects.length === 0 ? (
+                <div className="px-5 py-8 text-center font-mono text-xs text-zinc-400">No Vercel projects found.</div>
+              ) : (
+                filteredProjects.map((project) => {
+                  const unsupported = project.kind === "unsupported";
+                  return (
+                    <div
+                      key={project.id}
+                      className="flex items-center justify-between gap-4 border-b border-zinc-800 px-4 py-3.5 last:border-b-0"
+                    >
+                      <div className="min-w-0">
+                        <div className="text-sm font-semibold text-zinc-100">{project.name}</div>
+                        <div className="flex items-center gap-1.5 text-[11px] text-zinc-400 truncate max-w-sm mt-0.5 font-mono">
+                          <AppIcon icon={unsupported ? Alert02Icon : GithubIcon} size={12} />
+                          {project.sourceLabel}
+                        </div>
+                      </div>
+                      <button
+                        type="button"
+                        className="inline-flex items-center justify-center gap-2 border border-zinc-100/40 bg-zinc-100/10 px-3 py-2 font-mono text-[10px] font-semibold uppercase tracking-wider text-zinc-100 transition hover:bg-zinc-100/20 disabled:opacity-50"
+                        onClick={() => void handleSelectProject(project)}
+                        disabled={busy || unsupported}
+                      >
+                        Configure Import
+                      </button>
+                    </div>
+                  );
+                })
+              )}
+            </div>
+          </div>
+
+          <div className="flex justify-start border-t border-zinc-800 pt-4 mt-5">
+            <button type="button" className={shellButton("ghost")} onClick={() => setStep("auth")} disabled={busy}>
+              <AppIcon icon={ArrowLeft01Icon} size={16} />
+              Back
+            </button>
+          </div>
+        </div>
+      )}
+
+      {step === "configure" && projectDetails && (
+        <div className="flex flex-col min-h-full space-y-4">
+          <div className="text-sm text-zinc-300 leading-relaxed mb-1">
+            Customize how <strong>{selectedProject?.name}</strong> is migrated to your self-hosted stack.
+          </div>
+
+          <div className="grid grid-cols-2 gap-4">
+            <div>
+              <FieldLabel>Environment Variables Target</FieldLabel>
+              <Dropdown
+                value={target}
+                onChange={(value) => setTarget(value as VercelEnvTarget)}
+                disabled={busy}
+                options={projectDetails.targets.map((value) => ({ value, label: targetLabel[value] }))}
+              />
+              <div className="text-[10px] text-zinc-500 font-mono mt-1 uppercase tracking-wider">
+                Pull env vars from this Vercel target
+              </div>
+            </div>
+
+            <VercelMigrationOptions
+              busy={busy}
+              excludeSystemVars={excludeSystemVars}
+              autoDeploy={autoDeploy}
+              onExcludeSystemVarsChange={setExcludeSystemVars}
+              onAutoDeployChange={setAutoDeploy}
+            />
+          </div>
+
+          <div>
+            <FieldLabel>Source</FieldLabel>
+            <div className="border border-zinc-700 bg-zinc-900/85 px-4 py-3 space-y-1.5 font-mono text-[11px]">
+              {isUnsupported ? (
+                <div className="flex items-start gap-2 text-amber-200">
+                  <AppIcon icon={Alert02Icon} size={14} className="mt-0.5 shrink-0" />
+                  <span>{projectDetails.unsupportedReason}</span>
+                </div>
+              ) : (
+                <>
+                  <SummaryRow icon={GithubIcon} label="Repository" value={projectDetails.sourceLabel} />
+                  <SummaryRow label="Branch" value={projectDetails.branch || "main"} />
+                  {projectDetails.framework && <SummaryRow label="Framework" value={projectDetails.framework} />}
+                  {projectDetails.rootDirectory && <SummaryRow label="Root" value={projectDetails.rootDirectory} />}
+                </>
+              )}
+            </div>
+          </div>
+
+          {error && (
+            <div className="border border-rose-500/35 bg-rose-950/20 px-4 py-3 text-xs text-rose-300 font-mono">
+              {error}
+            </div>
+          )}
+
+          <div className="flex justify-between gap-3 border-t border-zinc-800 pt-4 mt-5">
+            <button type="button" className={shellButton("ghost")} onClick={() => setStep("select")} disabled={busy}>
+              <AppIcon icon={ArrowLeft01Icon} size={16} />
+              Back
+            </button>
+            <button
+              type="button"
+              className="inline-flex items-center justify-center gap-2 border border-zinc-100/40 bg-zinc-100/10 px-5 py-2.5 font-mono text-[11px] font-semibold uppercase tracking-wider text-zinc-100 transition hover:bg-zinc-100/20 disabled:opacity-60"
+              onClick={handleExecuteImport}
+              disabled={busy || isUnsupported}
+            >
+              <AppIcon icon={Globe02Icon} size={16} />
+              Start Migration
+            </button>
+          </div>
+        </div>
+      )}
+
+      {step === "importing" && (
+        <div className="py-8 flex flex-col items-center justify-center text-center space-y-4">
+          <div className="relative flex items-center justify-center">
+            <div className="h-12 w-12 rounded-full border-2 border-t-2 border-zinc-700 border-t-zinc-100 animate-spin" />
+            <AppIcon icon={WorkflowSquare07Icon} size={18} className="absolute text-zinc-100" />
+          </div>
+          <div>
+            <h3 className="font-semibold text-zinc-100 text-base">Migrating Project</h3>
+            <p className="text-xs text-zinc-400 font-mono mt-1">Importing "{selectedProject?.name}" from Vercel...</p>
+          </div>
+          <div className="w-64 h-1 border border-zinc-800 bg-zinc-950 overflow-hidden relative">
+            <div className="absolute inset-y-0 bg-gradient-to-r from-zinc-100 to-zinc-500 w-1/2 rounded-full animate-marquee" />
+          </div>
+          <div className="text-[10px] text-zinc-500 font-mono space-y-1">
+            <div>Resolving Git source and build commands...</div>
+            <div>Importing environment variables...</div>
+            <div>Importing custom domains and queueing the deploy...</div>
+          </div>
+        </div>
+      )}
+
+      {step === "success" && (
+        <div className="py-6 flex flex-col items-center justify-center text-center space-y-5">
+          <div className="h-14 w-14 rounded-full border border-emerald-500/30 bg-emerald-500/10 flex items-center justify-center text-emerald-400">
+            <AppIcon icon={CheckmarkCircle02Icon} size={30} />
+          </div>
+          <div>
+            <h3 className="font-hero text-xl font-bold text-zinc-100">Migration Completed!</h3>
+            <p className="text-sm text-zinc-300 max-w-sm mt-2">
+              Successfully imported "{selectedProject?.name}" from Vercel, including its Git source, build commands, and
+              environment variables.
+            </p>
+          </div>
+
+          <button
+            type="button"
+            className={shellButton("primary")}
+            onClick={() => {
+              handleClose();
+              void navigate({ to: "/$projectSlug", params: { projectSlug: importedSlug } });
+            }}
+          >
+            <AppIcon icon={WorkflowSquare07Icon} size={16} />
+            Go to Project Dashboard
+          </button>
+        </div>
+      )}
+    </ModalShell>
+  );
+}
+
+function SummaryRow({ icon, label, value }: { icon?: typeof GithubIcon; label: string; value: string }) {
+  return (
+    <div className="flex items-center gap-2 text-zinc-300">
+      <span className="inline-flex items-center gap-1.5 w-24 shrink-0 text-zinc-500 uppercase tracking-wider text-[10px]">
+        {icon && <AppIcon icon={icon} size={12} />}
+        {label}
+      </span>
+      <span className="truncate text-zinc-100">{value}</span>
+    </div>
+  );
+}

--- a/src/client/features/integrations/vercel-import-modal.tsx
+++ b/src/client/features/integrations/vercel-import-modal.tsx
@@ -1,20 +1,26 @@
-import { useState, useEffect } from "react";
 import {
-  Alert02Icon,
-  ArrowLeft01Icon,
-  CheckmarkCircle02Icon,
   GithubIcon,
-  Search01Icon,
-  WorkflowSquare07Icon,
   Globe02Icon,
-  Settings01Icon
+  Alert02Icon,
+  Search01Icon,
+  Settings01Icon,
+  ArrowLeft01Icon,
+  WorkflowSquare07Icon,
+  CheckmarkCircle02Icon,
 } from "@hugeicons/core-free-icons";
+import { useState, useEffect } from "react";
 import { useNavigate } from "@tanstack/react-router";
+
 import { api } from "../../api";
-import { ModalShell } from "../../components/modals/modal-shell";
+import {
+  AppIcon,
+  FormInput,
+  FieldLabel,
+  shellButton,
+} from "../../components/ui/primitives";
 import { Checkbox } from "../../components/ui/checkbox";
 import { Dropdown } from "../../components/ui/dropdown";
-import { AppIcon, FieldLabel, FormInput, shellButton } from "../../components/ui/primitives";
+import { ModalShell } from "../../components/modals/modal-shell";
 import { VercelMigrationOptions } from "./vercel-migration-options";
 
 interface VercelTeam {
@@ -26,9 +32,9 @@ interface VercelTeam {
 interface VercelProject {
   id: string;
   name: string;
+  sourceLabel: string;
   framework: string | null;
   kind: "git" | "unsupported";
-  sourceLabel: string;
 }
 
 type VercelEnvTarget = "production" | "preview" | "development";
@@ -36,15 +42,15 @@ type VercelEnvTarget = "production" | "preview" | "development";
 interface VercelProjectDetails {
   id: string;
   name: string;
-  framework: string | null;
-  rootDirectory: string | null;
-  buildCommand: string | null;
-  installCommand: string | null;
-  branch: string | null;
-  kind: "git" | "unsupported";
   sourceLabel: string;
-  unsupportedReason: string | null;
+  branch: string | null;
+  framework: string | null;
   targets: VercelEnvTarget[];
+  kind: "git" | "unsupported";
+  buildCommand: string | null;
+  rootDirectory: string | null;
+  installCommand: string | null;
+  unsupportedReason: string | null;
 }
 
 interface VercelImportModalProps {
@@ -53,144 +59,210 @@ interface VercelImportModalProps {
   onSuccess: () => void;
 }
 
+type ImportSummary = {
+  skippedSensitiveCount?: number;
+  importedVariableCount?: number;
+  importedCustomDomainCount?: number;
+};
+
+type Step = "auth" | "select" | "configure" | "importing" | "success";
+
+type State = {
+  step: Step;
+  busy: boolean;
+  scope: string;
+  error: string;
+  apiToken: string;
+  teams: VercelTeam[];
+  autoDeploy: boolean;
+  searchQuery: string;
+  importedSlug: string;
+  rememberToken: boolean;
+  target: VercelEnvTarget;
+  projects: VercelProject[];
+  excludeSystemVars: boolean;
+  summary: ImportSummary | null;
+  selectedProject: VercelProject | null;
+  projectDetails: VercelProjectDetails | null;
+};
+
 const PERSONAL_SCOPE = "";
 
 const targetLabel: Record<VercelEnvTarget, string> = {
-  production: "Production",
   preview: "Preview",
-  development: "Development"
+  production: "Production",
+  development: "Development",
 };
 
-export function VercelImportModal({ open, onClose, onSuccess }: VercelImportModalProps) {
-  const navigate = useNavigate();
-  const [step, setStep] = useState<"auth" | "select" | "configure" | "importing" | "success">("auth");
-  const [apiToken, setApiToken] = useState("");
-  const [teams, setTeams] = useState<VercelTeam[]>([]);
-  const [scope, setScope] = useState<string>(PERSONAL_SCOPE);
-  const [projects, setProjects] = useState<VercelProject[]>([]);
-  const [searchQuery, setSearchQuery] = useState("");
-  const [selectedProject, setSelectedProject] = useState<VercelProject | null>(null);
-  const [projectDetails, setProjectDetails] = useState<VercelProjectDetails | null>(null);
-  const [importedSlug, setImportedSlug] = useState("");
-  const [rememberToken, setRememberToken] = useState(() => {
-    const saved = localStorage.getItem("vercel_remember_token");
-    return saved !== "false";
-  });
-  const [busy, setBusy] = useState(false);
-  const [error, setError] = useState("");
+function createInitialState(): State {
+  return {
+    teams: [],
+    error: "",
+    busy: false,
+    step: "auth",
+    projects: [],
+    apiToken: "",
+    summary: null,
+    searchQuery: "",
+    autoDeploy: true,
+    importedSlug: "",
+    target: "production",
+    projectDetails: null,
+    selectedProject: null,
+    scope: PERSONAL_SCOPE,
+    excludeSystemVars: true,
+    rememberToken: localStorage.getItem("vercel_remember_token") !== "false",
+  };
+}
 
-  const [target, setTarget] = useState<VercelEnvTarget>("production");
-  const [excludeSystemVars, setExcludeSystemVars] = useState(true);
-  const [autoDeploy, setAutoDeploy] = useState(true);
+export function VercelImportModal({
+  open,
+  onClose,
+  onSuccess,
+}: VercelImportModalProps) {
+  const navigate = useNavigate();
+  const [state, setState] = useState<State>(createInitialState);
+  const update = (patch: Partial<State>) =>
+    setState((current) => ({ ...current, ...patch }));
+  const {
+    step,
+    apiToken,
+    teams,
+    scope,
+    projects,
+    searchQuery,
+    selectedProject,
+    projectDetails,
+    importedSlug,
+    summary,
+    rememberToken,
+    busy,
+    error,
+    target,
+    excludeSystemVars,
+    autoDeploy,
+  } = state;
 
   useEffect(() => {
     if (open) {
       const savedToken = localStorage.getItem("vercel_api_token");
-      if (savedToken) {
-        setApiToken(savedToken);
-      }
+      if (savedToken) update({ apiToken: savedToken });
     }
   }, [open]);
 
   const filteredProjects = projects.filter(
     (p) =>
       p.name.toLowerCase().includes(searchQuery.toLowerCase()) ||
-      p.sourceLabel.toLowerCase().includes(searchQuery.toLowerCase())
+      p.sourceLabel.toLowerCase().includes(searchQuery.toLowerCase()),
   );
 
-  async function loadProjectsForScope(token: string, teamId: string) {
+  async function loadProjects(token: string, teamId: string) {
     const data = await api.vercelProjects(token, teamId || undefined);
-    setProjects(data.projects);
+    update({ projects: data.projects });
   }
 
   async function handleConnect() {
     if (!apiToken.trim()) return;
     const token = apiToken.trim();
-    setBusy(true);
-    setError("");
+    update({ busy: true, error: "" });
     try {
-      const teamData = await api.vercelTeams(token).catch(() => ({ teams: [] }));
-      await loadProjectsForScope(token, PERSONAL_SCOPE);
-      localStorage.setItem("vercel_remember_token", rememberToken ? "true" : "false");
+      const teamData = await api
+        .vercelTeams(token)
+        .catch(() => ({ teams: [] }));
+      await loadProjects(token, PERSONAL_SCOPE);
+      localStorage.setItem(
+        "vercel_remember_token",
+        rememberToken ? "true" : "false",
+      );
       if (rememberToken) {
         localStorage.setItem("vercel_api_token", token);
       } else {
         localStorage.removeItem("vercel_api_token");
       }
-      setTeams(teamData.teams);
-      setScope(PERSONAL_SCOPE);
-      setStep("select");
+      update({ teams: teamData.teams, scope: PERSONAL_SCOPE, step: "select" });
     } catch (err) {
-      setError(err instanceof Error ? err.message : "Invalid Vercel API Token or connection failed");
+      update({
+        error:
+          err instanceof Error
+            ? err.message
+            : "Invalid Vercel API Token or connection failed",
+      });
     } finally {
-      setBusy(false);
+      update({ busy: false });
     }
   }
 
   async function handleScopeChange(nextScope: string) {
-    setScope(nextScope);
-    setBusy(true);
-    setError("");
+    update({ scope: nextScope, busy: true, error: "" });
     try {
-      await loadProjectsForScope(apiToken.trim(), nextScope);
+      await loadProjects(apiToken.trim(), nextScope);
     } catch (err) {
-      setError(err instanceof Error ? err.message : "Failed to load Vercel projects");
+      update({
+        error:
+          err instanceof Error ? err.message : "Failed to load Vercel projects",
+      });
     } finally {
-      setBusy(false);
+      update({ busy: false });
     }
   }
 
   async function handleSelectProject(project: VercelProject) {
-    setSelectedProject(project);
-    setBusy(true);
-    setError("");
+    update({ selectedProject: project, busy: true, error: "" });
     try {
-      const data = await api.vercelProjectDetails(apiToken.trim(), project.id, scope || undefined);
-      setProjectDetails(data.details);
-      setTarget(data.details.targets[0] ?? "production");
-      setExcludeSystemVars(true);
-      setAutoDeploy(true);
-      setStep("configure");
+      const data = await api.vercelProjectDetails(
+        apiToken.trim(),
+        project.id,
+        scope || undefined,
+      );
+      update({
+        projectDetails: data.details,
+        target: data.details.targets[0] ?? "production",
+        excludeSystemVars: true,
+        autoDeploy: true,
+        step: "configure",
+      });
     } catch (err) {
-      setError(err instanceof Error ? err.message : "Failed to load project details");
+      update({
+        error:
+          err instanceof Error ? err.message : "Failed to load project details",
+      });
     } finally {
-      setBusy(false);
+      update({ busy: false });
     }
   }
 
   async function handleExecuteImport() {
     if (!selectedProject) return;
-    setStep("importing");
-    setBusy(true);
-    setError("");
+    update({ step: "importing", busy: true, error: "" });
     try {
       const config = { target, excludeSystemVars, autoDeploy };
-      const result = await api.vercelImport(apiToken.trim(), selectedProject.id, scope || undefined, config);
-      setImportedSlug(result.projectSlug);
-      setStep("success");
+      const result = await api.vercelImport(
+        apiToken.trim(),
+        selectedProject.id,
+        scope || undefined,
+        config,
+      );
+      update({
+        importedSlug: result.projectSlug,
+        summary: result,
+        step: "success",
+      });
       onSuccess();
     } catch (err) {
-      setError(err instanceof Error ? err.message : "Migration failed");
-      setStep("configure");
+      update({
+        error: err instanceof Error ? err.message : "Migration failed",
+        step: "configure",
+      });
     } finally {
-      setBusy(false);
+      update({ busy: false });
     }
   }
 
   function handleClose() {
-    setStep("auth");
-    setApiToken("");
-    setTeams([]);
-    setScope(PERSONAL_SCOPE);
-    setProjects([]);
-    setSearchQuery("");
-    setSelectedProject(null);
-    setProjectDetails(null);
-    setImportedSlug("");
-    setError("");
-    setTarget("production");
-    setExcludeSystemVars(true);
-    setAutoDeploy(true);
+    setState((current) => ({
+      ...createInitialState(),
+      rememberToken: current.rememberToken,
+    }));
     onClose();
   }
 
@@ -198,12 +270,12 @@ export function VercelImportModal({ open, onClose, onSuccess }: VercelImportModa
     step === "auth"
       ? Settings01Icon
       : step === "select"
-      ? Search01Icon
-      : step === "configure"
-      ? Settings01Icon
-      : step === "importing"
-      ? WorkflowSquare07Icon
-      : CheckmarkCircle02Icon;
+        ? Search01Icon
+        : step === "configure"
+          ? Settings01Icon
+          : step === "importing"
+            ? WorkflowSquare07Icon
+            : CheckmarkCircle02Icon;
 
   const isUnsupported = projectDetails?.kind === "unsupported";
 
@@ -217,12 +289,12 @@ export function VercelImportModal({ open, onClose, onSuccess }: VercelImportModa
         step === "auth"
           ? "Step 1: Authenticate"
           : step === "select"
-          ? "Step 2: Choose Project"
-          : step === "configure"
-          ? "Step 3: Configure Migration"
-          : step === "importing"
-          ? "Migration In Progress"
-          : "Migration Complete"
+            ? "Step 2: Choose Project"
+            : step === "configure"
+              ? "Step 3: Configure Migration"
+              : step === "importing"
+                ? "Migration In Progress"
+                : "Migration Complete"
       }
       width="max-w-xl"
       bodyClassName="min-h-0 flex flex-1 flex-col overflow-hidden"
@@ -230,9 +302,10 @@ export function VercelImportModal({ open, onClose, onSuccess }: VercelImportModa
       {step === "auth" && (
         <div className="space-y-5">
           <div className="text-sm text-zinc-300 leading-relaxed">
-            Migrate a Vercel project to your self-hosted Aeroplane control plane. The connected Git repository, build
-            commands, environment variables, and custom domains are imported. Builds then run through Railpack on your
-            own server.
+            Migrate a Vercel project to your self-hosted Aeroplane control
+            plane. The connected Git repository, build commands, environment
+            variables, and custom domains are imported. Builds then run through
+            Railpack on your own server.
           </div>
 
           <div>
@@ -250,7 +323,7 @@ export function VercelImportModal({ open, onClose, onSuccess }: VercelImportModa
             <FormInput
               type="password"
               value={apiToken}
-              onChange={(e) => setApiToken(e.target.value)}
+              onChange={(e) => update({ apiToken: e.target.value })}
               placeholder="vercel_..."
               disabled={busy}
               autoComplete="new-password"
@@ -259,7 +332,7 @@ export function VercelImportModal({ open, onClose, onSuccess }: VercelImportModa
             <div className="mt-3">
               <Checkbox
                 checked={rememberToken}
-                onChange={setRememberToken}
+                onChange={(value) => update({ rememberToken: value })}
                 disabled={busy}
                 label="Remember my Vercel token"
               >
@@ -277,7 +350,12 @@ export function VercelImportModal({ open, onClose, onSuccess }: VercelImportModa
           )}
 
           <div className="flex justify-end gap-3 border-t border-zinc-800 pt-4 mt-5">
-            <button type="button" className={shellButton("ghost")} onClick={handleClose} disabled={busy}>
+            <button
+              type="button"
+              className={shellButton("ghost")}
+              onClick={handleClose}
+              disabled={busy}
+            >
               Cancel
             </button>
             <button
@@ -302,16 +380,20 @@ export function VercelImportModal({ open, onClose, onSuccess }: VercelImportModa
               disabled={busy}
               options={[
                 { value: PERSONAL_SCOPE, label: "Personal Account" },
-                ...teams.map((team) => ({ value: team.id, label: team.name }))
+                ...teams.map((team) => ({ value: team.id, label: team.name })),
               ]}
             />
           </div>
 
           <div className="relative mb-4">
-            <AppIcon icon={Search01Icon} size={16} className="pointer-events-none absolute left-3 top-3 text-zinc-500" />
+            <AppIcon
+              icon={Search01Icon}
+              size={16}
+              className="pointer-events-none absolute left-3 top-3 text-zinc-500"
+            />
             <FormInput
               value={searchQuery}
-              onChange={(e) => setSearchQuery(e.target.value)}
+              onChange={(e) => update({ searchQuery: e.target.value })}
               placeholder="Search Vercel projects"
               className="pl-10"
             />
@@ -326,7 +408,9 @@ export function VercelImportModal({ open, onClose, onSuccess }: VercelImportModa
           <div className="overflow-hidden border border-zinc-700 bg-zinc-900/85 flex-1 min-h-0">
             <div className="max-h-[300px] overflow-y-auto">
               {filteredProjects.length === 0 ? (
-                <div className="px-5 py-8 text-center font-mono text-xs text-zinc-400">No Vercel projects found.</div>
+                <div className="px-5 py-8 text-center font-mono text-xs text-zinc-400">
+                  No Vercel projects found.
+                </div>
               ) : (
                 filteredProjects.map((project) => {
                   const unsupported = project.kind === "unsupported";
@@ -336,9 +420,14 @@ export function VercelImportModal({ open, onClose, onSuccess }: VercelImportModa
                       className="flex items-center justify-between gap-4 border-b border-zinc-800 px-4 py-3.5 last:border-b-0"
                     >
                       <div className="min-w-0">
-                        <div className="text-sm font-semibold text-zinc-100">{project.name}</div>
+                        <div className="text-sm font-semibold text-zinc-100">
+                          {project.name}
+                        </div>
                         <div className="flex items-center gap-1.5 text-[11px] text-zinc-400 truncate max-w-sm mt-0.5 font-mono">
-                          <AppIcon icon={unsupported ? Alert02Icon : GithubIcon} size={12} />
+                          <AppIcon
+                            icon={unsupported ? Alert02Icon : GithubIcon}
+                            size={12}
+                          />
                           {project.sourceLabel}
                         </div>
                       </div>
@@ -358,7 +447,12 @@ export function VercelImportModal({ open, onClose, onSuccess }: VercelImportModa
           </div>
 
           <div className="flex justify-start border-t border-zinc-800 pt-4 mt-5">
-            <button type="button" className={shellButton("ghost")} onClick={() => setStep("auth")} disabled={busy}>
+            <button
+              type="button"
+              className={shellButton("ghost")}
+              onClick={() => update({ step: "auth" })}
+              disabled={busy}
+            >
               <AppIcon icon={ArrowLeft01Icon} size={16} />
               Back
             </button>
@@ -369,7 +463,8 @@ export function VercelImportModal({ open, onClose, onSuccess }: VercelImportModa
       {step === "configure" && projectDetails && (
         <div className="flex flex-col min-h-full space-y-4">
           <div className="text-sm text-zinc-300 leading-relaxed mb-1">
-            Customize how <strong>{selectedProject?.name}</strong> is migrated to your self-hosted stack.
+            Customize how <strong>{selectedProject?.name}</strong> is migrated
+            to your self-hosted stack.
           </div>
 
           <div className="grid grid-cols-2 gap-4">
@@ -377,9 +472,14 @@ export function VercelImportModal({ open, onClose, onSuccess }: VercelImportModa
               <FieldLabel>Environment Variables Target</FieldLabel>
               <Dropdown
                 value={target}
-                onChange={(value) => setTarget(value as VercelEnvTarget)}
+                onChange={(value) =>
+                  update({ target: value as VercelEnvTarget })
+                }
                 disabled={busy}
-                options={projectDetails.targets.map((value) => ({ value, label: targetLabel[value] }))}
+                options={projectDetails.targets.map((value) => ({
+                  value,
+                  label: targetLabel[value],
+                }))}
               />
               <div className="text-[10px] text-zinc-500 font-mono mt-1 uppercase tracking-wider">
                 Pull env vars from this Vercel target
@@ -390,8 +490,10 @@ export function VercelImportModal({ open, onClose, onSuccess }: VercelImportModa
               busy={busy}
               excludeSystemVars={excludeSystemVars}
               autoDeploy={autoDeploy}
-              onExcludeSystemVarsChange={setExcludeSystemVars}
-              onAutoDeployChange={setAutoDeploy}
+              onExcludeSystemVarsChange={(value) =>
+                update({ excludeSystemVars: value })
+              }
+              onAutoDeployChange={(value) => update({ autoDeploy: value })}
             />
           </div>
 
@@ -400,15 +502,36 @@ export function VercelImportModal({ open, onClose, onSuccess }: VercelImportModa
             <div className="border border-zinc-700 bg-zinc-900/85 px-4 py-3 space-y-1.5 font-mono text-[11px]">
               {isUnsupported ? (
                 <div className="flex items-start gap-2 text-amber-200">
-                  <AppIcon icon={Alert02Icon} size={14} className="mt-0.5 shrink-0" />
+                  <AppIcon
+                    icon={Alert02Icon}
+                    size={14}
+                    className="mt-0.5 shrink-0"
+                  />
                   <span>{projectDetails.unsupportedReason}</span>
                 </div>
               ) : (
                 <>
-                  <SummaryRow icon={GithubIcon} label="Repository" value={projectDetails.sourceLabel} />
-                  <SummaryRow label="Branch" value={projectDetails.branch || "main"} />
-                  {projectDetails.framework && <SummaryRow label="Framework" value={projectDetails.framework} />}
-                  {projectDetails.rootDirectory && <SummaryRow label="Root" value={projectDetails.rootDirectory} />}
+                  <SummaryRow
+                    icon={GithubIcon}
+                    label="Repository"
+                    value={projectDetails.sourceLabel}
+                  />
+                  <SummaryRow
+                    label="Branch"
+                    value={projectDetails.branch || "main"}
+                  />
+                  {projectDetails.framework && (
+                    <SummaryRow
+                      label="Framework"
+                      value={projectDetails.framework}
+                    />
+                  )}
+                  {projectDetails.rootDirectory && (
+                    <SummaryRow
+                      label="Root"
+                      value={projectDetails.rootDirectory}
+                    />
+                  )}
                 </>
               )}
             </div>
@@ -421,7 +544,12 @@ export function VercelImportModal({ open, onClose, onSuccess }: VercelImportModa
           )}
 
           <div className="flex justify-between gap-3 border-t border-zinc-800 pt-4 mt-5">
-            <button type="button" className={shellButton("ghost")} onClick={() => setStep("select")} disabled={busy}>
+            <button
+              type="button"
+              className={shellButton("ghost")}
+              onClick={() => update({ step: "select" })}
+              disabled={busy}
+            >
               <AppIcon icon={ArrowLeft01Icon} size={16} />
               Back
             </button>
@@ -442,11 +570,19 @@ export function VercelImportModal({ open, onClose, onSuccess }: VercelImportModa
         <div className="py-8 flex flex-col items-center justify-center text-center space-y-4">
           <div className="relative flex items-center justify-center">
             <div className="h-12 w-12 rounded-full border-2 border-t-2 border-zinc-700 border-t-zinc-100 animate-spin" />
-            <AppIcon icon={WorkflowSquare07Icon} size={18} className="absolute text-zinc-100" />
+            <AppIcon
+              icon={WorkflowSquare07Icon}
+              size={18}
+              className="absolute text-zinc-100"
+            />
           </div>
           <div>
-            <h3 className="font-semibold text-zinc-100 text-base">Migrating Project</h3>
-            <p className="text-xs text-zinc-400 font-mono mt-1">Importing "{selectedProject?.name}" from Vercel...</p>
+            <h3 className="font-semibold text-zinc-100 text-base">
+              Migrating Project
+            </h3>
+            <p className="text-xs text-zinc-400 font-mono mt-1">
+              Importing "{selectedProject?.name}" from Vercel...
+            </p>
           </div>
           <div className="w-64 h-1 border border-zinc-800 bg-zinc-950 overflow-hidden relative">
             <div className="absolute inset-y-0 bg-gradient-to-r from-zinc-100 to-zinc-500 w-1/2 rounded-full animate-marquee" />
@@ -465,19 +601,57 @@ export function VercelImportModal({ open, onClose, onSuccess }: VercelImportModa
             <AppIcon icon={CheckmarkCircle02Icon} size={30} />
           </div>
           <div>
-            <h3 className="font-hero text-xl font-bold text-zinc-100">Migration Completed!</h3>
+            <h3 className="font-hero text-xl font-bold text-zinc-100">
+              Migration Completed!
+            </h3>
             <p className="text-sm text-zinc-300 max-w-sm mt-2">
-              Successfully imported "{selectedProject?.name}" from Vercel, including its Git source, build commands, and
-              environment variables.
+              Successfully imported "{selectedProject?.name}" from Vercel,
+              including its Git source and build commands.
             </p>
           </div>
+
+          {summary && (
+            <div className="w-full max-w-sm border border-zinc-800 bg-zinc-900/60 px-4 py-3 space-y-1.5 text-left font-mono text-[11px]">
+              <div className="flex justify-between text-zinc-300">
+                <span className="text-zinc-500 uppercase tracking-wider">
+                  Variables
+                </span>
+                <span>{summary.importedVariableCount ?? 0} imported</span>
+              </div>
+              <div className="flex justify-between text-zinc-300">
+                <span className="text-zinc-500 uppercase tracking-wider">
+                  Domains
+                </span>
+                <span>{summary.importedCustomDomainCount ?? 0} imported</span>
+              </div>
+              {Boolean(summary.skippedSensitiveCount) && (
+                <div className="flex items-start gap-2 border-t border-zinc-800 pt-2 mt-1 text-amber-200">
+                  <AppIcon
+                    icon={Alert02Icon}
+                    size={13}
+                    className="mt-0.5 shrink-0"
+                  />
+                  <span>
+                    {summary.skippedSensitiveCount} sensitive variable
+                    {summary.skippedSensitiveCount === 1 ? "" : "s"}{" "}
+                    couldn&apos;t be read from Vercel — add{" "}
+                    {summary.skippedSensitiveCount === 1 ? "it" : "them"}{" "}
+                    manually.
+                  </span>
+                </div>
+              )}
+            </div>
+          )}
 
           <button
             type="button"
             className={shellButton("primary")}
             onClick={() => {
               handleClose();
-              void navigate({ to: "/$projectSlug", params: { projectSlug: importedSlug } });
+              void navigate({
+                to: "/$projectSlug",
+                params: { projectSlug: importedSlug },
+              });
             }}
           >
             <AppIcon icon={WorkflowSquare07Icon} size={16} />
@@ -489,7 +663,15 @@ export function VercelImportModal({ open, onClose, onSuccess }: VercelImportModa
   );
 }
 
-function SummaryRow({ icon, label, value }: { icon?: typeof GithubIcon; label: string; value: string }) {
+function SummaryRow({
+  icon,
+  label,
+  value,
+}: {
+  icon?: typeof GithubIcon;
+  label: string;
+  value: string;
+}) {
   return (
     <div className="flex items-center gap-2 text-zinc-300">
       <span className="inline-flex items-center gap-1.5 w-24 shrink-0 text-zinc-500 uppercase tracking-wider text-[10px]">

--- a/src/client/features/integrations/vercel-migration-options.tsx
+++ b/src/client/features/integrations/vercel-migration-options.tsx
@@ -1,0 +1,43 @@
+import { Checkbox } from "../../components/ui/checkbox";
+
+type VercelMigrationOptionsProps = {
+  busy: boolean;
+  excludeSystemVars: boolean;
+  autoDeploy: boolean;
+  onExcludeSystemVarsChange: (checked: boolean) => void;
+  onAutoDeployChange: (checked: boolean) => void;
+};
+
+export function VercelMigrationOptions({
+  busy,
+  excludeSystemVars,
+  autoDeploy,
+  onExcludeSystemVarsChange,
+  onAutoDeployChange
+}: VercelMigrationOptionsProps) {
+  return (
+    <div className="flex flex-col justify-end space-y-2.5 pb-1">
+      <Checkbox
+        checked={excludeSystemVars}
+        onChange={onExcludeSystemVarsChange}
+        disabled={busy}
+        label="Exclude VERCEL_* variables"
+      >
+        <span className="text-xs text-zinc-300 font-semibold font-mono uppercase tracking-wider">
+          Exclude VERCEL_* variables
+        </span>
+      </Checkbox>
+
+      <Checkbox
+        checked={autoDeploy}
+        onChange={onAutoDeployChange}
+        disabled={busy}
+        label="Auto-deploy service"
+      >
+        <span className="text-xs text-zinc-300 font-semibold font-mono uppercase tracking-wider">
+          Auto-deploy service
+        </span>
+      </Checkbox>
+    </div>
+  );
+}

--- a/src/client/pages/projects-page.tsx
+++ b/src/client/pages/projects-page.tsx
@@ -18,6 +18,7 @@ import { ServiceCluster } from "../features/projects/service-cluster";
 import { SystemHealthPill } from "../features/projects/system-health-pill";
 import { SetupTodoList } from "../features/projects/setup-todo-list";
 import { RailwayImportModal } from "../features/integrations/railway-import-modal";
+import { VercelImportModal } from "../features/integrations/vercel-import-modal";
 import type { SystemSettingsTab } from "../components/modals/system-settings-types";
 import { SignOutButton } from "../components/auth/sign-out-button";
 import { serviceIsDeploying } from "../lib/deployment-status";
@@ -38,6 +39,7 @@ export function ProjectsPage() {
   const [setupLoading, setSetupLoading] = useState(true);
   const [createOpen, setCreateOpen] = useState(false);
   const [railwayImportOpen, setRailwayImportOpen] = useState(false);
+  const [vercelImportOpen, setVercelImportOpen] = useState(false);
   const [githubInstallOpen, setGitHubInstallOpen] = useState(false);
   const [error, setError] = useState("");
 
@@ -202,7 +204,16 @@ export function ProjectsPage() {
               >
                 <AppIcon icon={AddSquareIcon} size={14} />
                 <span className="hidden md:inline">Import Railway</span>
-                <span className="md:hidden">Import</span>
+                <span className="md:hidden">Railway</span>
+              </button>
+              <button
+                type="button"
+                className="inline-flex h-9 items-center justify-center gap-2 border border-zinc-100/40 bg-zinc-100/10 px-3 font-mono text-[10px] font-semibold uppercase tracking-[0.16em] text-zinc-100 transition-colors hover:bg-zinc-100/20"
+                onClick={() => setVercelImportOpen(true)}
+              >
+                <AppIcon icon={AddSquareIcon} size={14} />
+                <span className="hidden md:inline">Import Vercel</span>
+                <span className="md:hidden">Vercel</span>
               </button>
               <button
                 type="button"
@@ -314,6 +325,11 @@ export function ProjectsPage() {
       <RailwayImportModal
         open={railwayImportOpen}
         onClose={() => setRailwayImportOpen(false)}
+        onSuccess={loadProjects}
+      />
+      <VercelImportModal
+        open={vercelImportOpen}
+        onClose={() => setVercelImportOpen(false)}
         onSuccess={loadProjects}
       />
       <GitHubInstallModal

--- a/src/server/deploy.ts
+++ b/src/server/deploy.ts
@@ -69,12 +69,22 @@ function now() {
   return nowIso();
 }
 
+// Docker reference components only allow `.`, `_`, `__`, or runs of `-` between
+// alphanumerics. Collapse any other separator run (e.g. `_-` from a nanoid id,
+// `___`, `..`) to a single `-`, leaving already-valid separators untouched.
+function normalizeDockerSeparators(value: string) {
+  return value.replace(/[._-]+/g, (sep) => {
+    if (/^-+$/.test(sep) || sep === "_" || sep === "__" || sep === ".") return sep;
+    return "-";
+  });
+}
+
 function safeSlug(value: string) {
-  return value.toLowerCase().replace(/[^a-z0-9_.-]+/g, "-").replace(/^[^a-z0-9]+|[^a-z0-9]+$/g, "").slice(0, 48) || "app";
+  return normalizeDockerSeparators(value.toLowerCase().replace(/[^a-z0-9_.-]+/g, "-")).replace(/^[^a-z0-9]+|[^a-z0-9]+$/g, "").slice(0, 48) || "app";
 }
 
 function safeDockerIdentifier(value: string, fallback: string) {
-  return value.toLowerCase().replace(/[^a-z0-9_.-]+/g, "-").replace(/^[^a-z0-9]+|[^a-z0-9]+$/g, "") || fallback;
+  return normalizeDockerSeparators(value.toLowerCase().replace(/[^a-z0-9_.-]+/g, "-")).replace(/^[^a-z0-9]+|[^a-z0-9]+$/g, "") || fallback;
 }
 
 export function containerNameForService(serviceId: string) {

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -27,6 +27,7 @@ import { envExampleVariableSuggestions } from "./env-example-suggestions.js";
 import { resolveServiceEnv } from "./variable-resolver.js";
 import { getRailwayProjects, getRailwayProjectDetails, importRailwayProject } from "./railway-importer.js";
 import { startRailwayImportAutomation } from "./railway-import-automation.js";
+import { getVercelTeams, getVercelProjects, getVercelProjectDetails, importVercelProject } from "./vercel-importer.js";
 import { githubConnectionStatus, listConnectedRepos, listRepoBranches, listRepoDirectories, repoUrlFromFullName } from "./github-connect.js";
 import { branchFromGitRef, verifyGitHubSignature } from "./github.js";
 import { subscribeToDeploymentLogs } from "./logBus.js";
@@ -3182,6 +3183,89 @@ app.post("/api/integrations/railway/import", async (c) => {
     });
   } catch (error) {
     const msg = error instanceof Error ? error.message : "Failed to import Railway project";
+    return jsonError(msg);
+  }
+});
+
+app.post("/api/integrations/vercel/teams", async (c) => {
+  try {
+    const body = await c.req.json();
+    const token = body?.apiToken;
+    if (!token) {
+      return jsonError("API Token is required");
+    }
+    const teams = await getVercelTeams(token);
+    return c.json({ teams });
+  } catch (error) {
+    const msg = error instanceof Error ? error.message : "Failed to load Vercel teams";
+    return jsonError(msg);
+  }
+});
+
+app.post("/api/integrations/vercel/projects", async (c) => {
+  try {
+    const body = await c.req.json();
+    const token = body?.apiToken;
+    if (!token) {
+      return jsonError("API Token is required");
+    }
+    const teamId = optionalString.parse(body?.teamId);
+    const projects = await getVercelProjects(token, teamId);
+    return c.json({ projects });
+  } catch (error) {
+    const msg = error instanceof Error ? error.message : "Failed to load Vercel projects";
+    return jsonError(msg);
+  }
+});
+
+app.post("/api/integrations/vercel/project-details", async (c) => {
+  try {
+    const body = await c.req.json();
+    const token = body?.apiToken;
+    const projectId = body?.projectId;
+    if (!token || !projectId) {
+      return jsonError("API Token and Project ID are required");
+    }
+    const teamId = optionalString.parse(body?.teamId);
+    const details = await getVercelProjectDetails(token, projectId, teamId);
+    return c.json({ details });
+  } catch (error) {
+    const msg = error instanceof Error ? error.message : "Failed to load Vercel project details";
+    return jsonError(msg);
+  }
+});
+
+app.post("/api/integrations/vercel/import", async (c) => {
+  try {
+    const body = await c.req.json();
+    const token = body?.apiToken;
+    const projectId = body?.projectId;
+    const config = body?.config || {};
+    if (!token || !projectId) {
+      return jsonError("API Token and Project ID are required");
+    }
+    const ownerUserId = actorUserId(c);
+    if (!ownerUserId) {
+      return jsonError("Authenticated user not found", 401);
+    }
+    const teamId = optionalString.parse(body?.teamId);
+    const result = await importVercelProject(token, projectId, config, { ownerUserId, teamId });
+
+    if (config.autoDeploy !== false) {
+      for (const serviceId of result.appServiceIds) {
+        enqueueDeployment(serviceId, { trigger: "manual" });
+      }
+    }
+
+    return c.json({
+      ok: true,
+      projectSlug: result.projectSlug,
+      importedCustomDomainCount: result.importedCustomDomainCount,
+      importedVariableCount: result.importedVariableCount,
+      skippedSensitiveCount: result.skippedSensitiveCount
+    });
+  } catch (error) {
+    const msg = error instanceof Error ? error.message : "Failed to import Vercel project";
     return jsonError(msg);
   }
 });

--- a/src/server/service-import-sources.ts
+++ b/src/server/service-import-sources.ts
@@ -5,7 +5,7 @@ import { serviceImportSources, type ServiceImportSource } from "./schema.js";
 
 type RecordServiceImportSourceInput = {
   serviceId: string;
-  provider: "railway";
+  provider: "railway" | "vercel";
   externalProjectId?: string | null;
   externalEnvironmentId?: string | null;
   externalServiceId: string;

--- a/src/server/vercel-api.ts
+++ b/src/server/vercel-api.ts
@@ -1,0 +1,44 @@
+const vercelApiBase = process.env.VERCEL_API_BASE ?? "https://api.vercel.com";
+
+type VercelRequestOptions = {
+  teamId?: string;
+  method?: string;
+  body?: unknown;
+  query?: Record<string, string | number | boolean | undefined>;
+};
+
+export async function fetchVercel<T = any>(token: string, path: string, options: VercelRequestOptions = {}): Promise<T> {
+  const url = new URL(path, vercelApiBase);
+  if (options.teamId) {
+    url.searchParams.set("teamId", options.teamId);
+  }
+  for (const [key, value] of Object.entries(options.query ?? {})) {
+    if (value !== undefined) {
+      url.searchParams.set(key, String(value));
+    }
+  }
+
+  const res = await fetch(url, {
+    method: options.method ?? "GET",
+    headers: {
+      Authorization: `Bearer ${token}`,
+      ...(options.body ? { "Content-Type": "application/json" } : {})
+    },
+    body: options.body ? JSON.stringify(options.body) : undefined
+  });
+
+  if (!res.ok) {
+    let message = res.statusText;
+    try {
+      const errorBody = (await res.json()) as { error?: { message?: string } };
+      if (errorBody?.error?.message) {
+        message = errorBody.error.message;
+      }
+    } catch {
+      // Response body was not JSON; fall back to the status text.
+    }
+    throw new Error(`Vercel API request failed: ${message}`);
+  }
+
+  return (await res.json()) as T;
+}

--- a/src/server/vercel-api.ts
+++ b/src/server/vercel-api.ts
@@ -1,13 +1,17 @@
 const vercelApiBase = process.env.VERCEL_API_BASE ?? "https://api.vercel.com";
 
 type VercelRequestOptions = {
+  body?: unknown;
   teamId?: string;
   method?: string;
-  body?: unknown;
   query?: Record<string, string | number | boolean | undefined>;
 };
 
-export async function fetchVercel<T = any>(token: string, path: string, options: VercelRequestOptions = {}): Promise<T> {
+export async function fetchVercel<T = any>(
+  token: string,
+  path: string,
+  options: VercelRequestOptions = {},
+): Promise<T> {
   const url = new URL(path, vercelApiBase);
   if (options.teamId) {
     url.searchParams.set("teamId", options.teamId);
@@ -18,14 +22,21 @@ export async function fetchVercel<T = any>(token: string, path: string, options:
     }
   }
 
-  const res = await fetch(url, {
-    method: options.method ?? "GET",
-    headers: {
-      Authorization: `Bearer ${token}`,
-      ...(options.body ? { "Content-Type": "application/json" } : {})
-    },
-    body: options.body ? JSON.stringify(options.body) : undefined
-  });
+  let res: Response;
+  try {
+    res = await fetch(url, {
+      method: options.method ?? "GET",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        ...(options.body ? { "Content-Type": "application/json" } : {}),
+      },
+      body: options.body ? JSON.stringify(options.body) : undefined,
+    });
+  } catch {
+    throw new Error(
+      "Could not reach Vercel. Check your network connection and try again.",
+    );
+  }
 
   if (!res.ok) {
     let message = res.statusText;
@@ -35,7 +46,7 @@ export async function fetchVercel<T = any>(token: string, path: string, options:
         message = errorBody.error.message;
       }
     } catch {
-      // Response body was not JSON; fall back to the status text.
+      // Pass: Response body was not JSON; fall back to the status text.
     }
     throw new Error(`Vercel API request failed: ${message}`);
   }

--- a/src/server/vercel-importer.ts
+++ b/src/server/vercel-importer.ts
@@ -1,0 +1,389 @@
+import { eq } from "drizzle-orm";
+import { nanoid } from "nanoid";
+import { db, nowIso } from "./db.js";
+import { domains, envVars, projectGroups, services } from "./schema.js";
+import { allocateHostPort } from "./deploy.js";
+import { writeAndReloadCaddy } from "./caddy.js";
+import { ensureDefaultDomainForService } from "./service-domains.js";
+import { recordServiceImportSource } from "./service-import-sources.js";
+import { repoUrlFromFullName } from "./github-connect.js";
+import { fetchVercel } from "./vercel-api.js";
+
+type VercelGitLink = {
+  type?: string | null;
+  // GitHub
+  org?: string | null;
+  repo?: string | null;
+  // GitLab
+  projectNamespace?: string | null;
+  projectName?: string | null;
+  // Bitbucket
+  owner?: string | null;
+  slug?: string | null;
+  name?: string | null;
+  productionBranch?: string | null;
+};
+
+type VercelProjectNode = {
+  id: string;
+  name: string;
+  framework?: string | null;
+  rootDirectory?: string | null;
+  buildCommand?: string | null;
+  installCommand?: string | null;
+  outputDirectory?: string | null;
+  link?: VercelGitLink | null;
+};
+
+type VercelEnvNode = {
+  key?: string | null;
+  value?: string | null;
+  type?: string | null;
+  target?: string[] | string | null;
+};
+
+export type VercelEnvTarget = "production" | "preview" | "development";
+
+const vercelEnvTargets: VercelEnvTarget[] = ["production", "preview", "development"];
+
+type VercelProjectClassification = {
+  kind: "git" | "unsupported";
+  repoUrl?: string;
+  repoFullName?: string | null;
+  branch?: string;
+  sourceLabel: string;
+  unsupportedReason?: string;
+};
+
+function cleanOptionalString(value: unknown) {
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  return trimmed || undefined;
+}
+
+function numericPort(value: unknown) {
+  const port = Number(value);
+  if (Number.isInteger(port) && port > 0 && port <= 65535) {
+    return port;
+  }
+  return null;
+}
+
+function uniqueSlug(base: string, exists: (slug: string) => boolean) {
+  const normalized = base.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "");
+  const baseSlug = normalized || "project";
+  let slug = baseSlug;
+  let counter = 1;
+  while (exists(slug)) {
+    slug = `${baseSlug}-${counter++}`;
+  }
+  return slug;
+}
+
+function gitRepoFromLink(link: VercelGitLink): { host: string; owner: string; repo: string } | null {
+  if (link.type === "github" && link.org && link.repo) {
+    return { host: "github.com", owner: link.org, repo: link.repo };
+  }
+  if (link.type === "gitlab" && link.projectNamespace && link.projectName) {
+    return { host: "gitlab.com", owner: link.projectNamespace, repo: link.projectName };
+  }
+  if (link.type === "bitbucket" && link.owner && (link.slug || link.name)) {
+    return { host: "bitbucket.org", owner: link.owner, repo: (link.slug || link.name) as string };
+  }
+  return null;
+}
+
+function classifyVercelProjectSource(project: VercelProjectNode): VercelProjectClassification {
+  const link = project.link;
+  if (!link || !link.type) {
+    return {
+      kind: "unsupported",
+      sourceLabel: "No Git repository connected",
+      unsupportedReason: "This Vercel project has no connected Git repository for Aeroplane to deploy from."
+    };
+  }
+
+  const repo = gitRepoFromLink(link);
+  if (!repo) {
+    return {
+      kind: "unsupported",
+      sourceLabel: `Unsupported Git provider (${link.type})`,
+      unsupportedReason: "Aeroplane could not resolve a Git repository from this Vercel project."
+    };
+  }
+
+  const branch = cleanOptionalString(link.productionBranch) ?? "main";
+  const fullName = `${repo.owner}/${repo.repo}`;
+  // GitHub repos integrate with Aeroplane's GitHub App; other providers only get a clone URL.
+  const isGitHub = repo.host === "github.com";
+
+  return {
+    kind: "git",
+    repoUrl: isGitHub ? repoUrlFromFullName(fullName) : `https://${repo.host}/${fullName}.git`,
+    repoFullName: isGitHub ? fullName : null,
+    branch,
+    sourceLabel: fullName
+  };
+}
+
+function envTargetMatches(target: VercelEnvNode["target"], selected: VercelEnvTarget) {
+  if (Array.isArray(target)) return target.includes(selected);
+  if (typeof target === "string") return target === selected;
+  return false;
+}
+
+async function getVercelProjectEnv(token: string, projectId: string, target: VercelEnvTarget, teamId?: string) {
+  const data = await fetchVercel<{ envs?: VercelEnvNode[] }>(token, `/v9/projects/${encodeURIComponent(projectId)}/env`, {
+    teamId,
+    query: { decrypt: "true" }
+  });
+
+  const vars: Record<string, string> = {};
+  let skippedSensitive = 0;
+  for (const env of data.envs ?? []) {
+    if (!env.key || !envTargetMatches(env.target, target)) continue;
+    // Sensitive variables cannot be decrypted through the API and come back empty.
+    if (typeof env.value !== "string" || env.value.length === 0) {
+      skippedSensitive += 1;
+      continue;
+    }
+    vars[env.key] = env.value;
+  }
+
+  return { vars, skippedSensitive };
+}
+
+async function getVercelProjectCustomDomains(token: string, projectId: string, teamId?: string) {
+  const data = await fetchVercel<{ domains?: Array<{ name?: string | null }> }>(
+    token,
+    `/v9/projects/${encodeURIComponent(projectId)}/domains`,
+    { teamId }
+  );
+
+  const hostnames: string[] = [];
+  for (const domain of data.domains ?? []) {
+    const hostname = typeof domain.name === "string" ? domain.name.trim().toLowerCase() : "";
+    // Skip Vercel-managed hostnames; they can't be routed to the self-hosted server.
+    if (!hostname || hostname.endsWith(".vercel.app")) continue;
+    hostnames.push(hostname);
+  }
+  return hostnames;
+}
+
+function importCustomDomains(serviceId: string, hostnames: string[], timestamp: string) {
+  let imported = 0;
+  for (const hostname of hostnames) {
+    const existing = db.select({ id: domains.id }).from(domains).where(eq(domains.hostname, hostname)).get();
+    if (existing) continue;
+    db.insert(domains)
+      .values({
+        id: nanoid(10),
+        serviceId,
+        hostname,
+        status: "pending",
+        createdAt: timestamp,
+        updatedAt: timestamp
+      })
+      .run();
+    imported += 1;
+  }
+  return imported;
+}
+
+export async function getVercelTeams(token: string) {
+  const data = await fetchVercel<{ teams?: Array<{ id: string; slug?: string | null; name?: string | null }> }>(token, "/v2/teams");
+  return (data.teams ?? []).map((team) => ({
+    id: team.id,
+    slug: team.slug ?? team.id,
+    name: team.name || team.slug || team.id
+  }));
+}
+
+export async function getVercelProjects(token: string, teamId?: string) {
+  const data = await fetchVercel<{ projects?: VercelProjectNode[] }>(token, "/v9/projects", {
+    teamId,
+    query: { limit: 100 }
+  });
+
+  return (data.projects ?? []).map((project) => {
+    const classification = classifyVercelProjectSource(project);
+    return {
+      id: project.id,
+      name: project.name,
+      framework: project.framework ?? null,
+      kind: classification.kind,
+      sourceLabel: classification.sourceLabel
+    };
+  });
+}
+
+export async function getVercelProjectDetails(token: string, projectId: string, teamId?: string) {
+  const project = await fetchVercel<VercelProjectNode>(token, `/v9/projects/${encodeURIComponent(projectId)}`, { teamId });
+  if (!project?.id) {
+    throw new Error("Vercel project not found");
+  }
+
+  const classification = classifyVercelProjectSource(project);
+  return {
+    id: project.id,
+    name: project.name,
+    framework: project.framework ?? null,
+    rootDirectory: cleanOptionalString(project.rootDirectory) ?? null,
+    buildCommand: cleanOptionalString(project.buildCommand) ?? null,
+    installCommand: cleanOptionalString(project.installCommand) ?? null,
+    branch: classification.branch ?? null,
+    kind: classification.kind,
+    sourceLabel: classification.sourceLabel,
+    unsupportedReason: classification.unsupportedReason ?? null,
+    targets: vercelEnvTargets
+  };
+}
+
+export interface VercelImportConfig {
+  target?: VercelEnvTarget;
+  excludeSystemVars?: boolean;
+  autoDeploy?: boolean;
+}
+
+export async function importVercelProject(
+  token: string,
+  vercelProjectId: string,
+  config: VercelImportConfig,
+  options: { ownerUserId: string; teamId?: string }
+) {
+  const project = await fetchVercel<VercelProjectNode>(token, `/v9/projects/${encodeURIComponent(vercelProjectId)}`, {
+    teamId: options.teamId
+  });
+  if (!project?.id) {
+    throw new Error("Vercel project not found or token has insufficient permissions");
+  }
+
+  const classification = classifyVercelProjectSource(project);
+  if (classification.kind === "unsupported") {
+    throw new Error(classification.unsupportedReason ?? "This Vercel project cannot be imported.");
+  }
+
+  const target = config.target && vercelEnvTargets.includes(config.target) ? config.target : "production";
+  const timestamp = nowIso();
+  const projectGroupId = nanoid(10);
+
+  const projectSlug = uniqueSlug(
+    project.name,
+    (slug) => Boolean(db.select({ id: projectGroups.id }).from(projectGroups).where(eq(projectGroups.slug, slug)).get())
+  );
+
+  db.insert(projectGroups)
+    .values({
+      id: projectGroupId,
+      ownerUserId: options.ownerUserId,
+      name: project.name,
+      slug: projectSlug,
+      description: null,
+      createdAt: timestamp,
+      updatedAt: timestamp
+    })
+    .run();
+
+  const serviceSlug = uniqueSlug(
+    project.name,
+    (slug) => Boolean(db.select({ id: services.id }).from(services).where(eq(services.slug, slug)).get())
+  );
+
+  const { vars: fetchedVars, skippedSensitive } = await getVercelProjectEnv(token, vercelProjectId, target, options.teamId).catch(
+    () => ({ vars: {} as Record<string, string>, skippedSensitive: 0 })
+  );
+
+  let internalPort = 8080;
+  const envPort = numericPort(fetchedVars.PORT);
+  if (envPort) {
+    internalPort = envPort;
+  }
+
+  const targetServiceId = nanoid(10);
+  db.insert(services)
+    .values({
+      id: targetServiceId,
+      projectId: projectGroupId,
+      slug: serviceSlug,
+      name: project.name,
+      repoFullName: classification.repoFullName ?? null,
+      repoUrl: classification.repoUrl ?? "",
+      branch: classification.branch ?? "main",
+      rootDir: cleanOptionalString(project.rootDirectory) ?? null,
+      githubToken: null,
+      webhookSecret: nanoid(24),
+      installCommand: cleanOptionalString(project.installCommand) ?? null,
+      buildCommand: cleanOptionalString(project.buildCommand) ?? null,
+      startCommand: null,
+      staticOutput: null,
+      runtimeMode: "web",
+      internalPort,
+      hostPort: allocateHostPort(),
+      activePort: null,
+      databasePublicEnabled: false,
+      databasePublicHostname: null,
+      postgresLogicalReplicationEnabled: false,
+      status: "idle",
+      lastDeployedAt: null,
+      createdAt: timestamp,
+      updatedAt: timestamp
+    })
+    .run();
+
+  const createdService = db.select().from(services).where(eq(services.id, targetServiceId)).get();
+  let importedCustomDomainCount = 0;
+  if (createdService) {
+    ensureDefaultDomainForService(createdService);
+    try {
+      const customDomains = await getVercelProjectCustomDomains(token, vercelProjectId, options.teamId);
+      importedCustomDomainCount = importCustomDomains(targetServiceId, customDomains, timestamp);
+    } catch {
+      // Domain import should not block service migration.
+    }
+  }
+
+  recordServiceImportSource({
+    serviceId: targetServiceId,
+    provider: "vercel",
+    externalProjectId: vercelProjectId,
+    externalEnvironmentId: target,
+    externalServiceId: vercelProjectId,
+    externalServiceName: project.name,
+    metadata: {
+      projectName: project.name,
+      target,
+      framework: project.framework ?? null,
+      sourceRepo: classification.sourceLabel,
+      teamId: options.teamId ?? null
+    }
+  });
+
+  let importedVariableCount = 0;
+  for (const [key, value] of Object.entries(fetchedVars)) {
+    if (config.excludeSystemVars && key.startsWith("VERCEL_")) {
+      continue;
+    }
+    db.insert(envVars)
+      .values({
+        id: nanoid(10),
+        serviceId: targetServiceId,
+        key,
+        value,
+        createdAt: timestamp,
+        updatedAt: timestamp
+      })
+      .run();
+    importedVariableCount += 1;
+  }
+
+  await writeAndReloadCaddy();
+
+  return {
+    projectId: projectGroupId,
+    projectSlug,
+    appServiceIds: [targetServiceId],
+    importedCustomDomainCount,
+    importedVariableCount,
+    skippedSensitiveCount: skippedSensitive
+  };
+}


### PR DESCRIPTION
# PR Summary

This PR adds the ability to **import projects from Vercel**, mirroring the existing "Import from Railway" flow. A user connects a Vercel API token, picks a project, and Aeroplane recreates it as a self-hosted service.

## What it does

- **Connect & scope:** Authenticate with a Vercel API token; choose Personal account or a Team.
- **Browse & select:** Lists Vercel projects; projects with no connected Git repo are flagged **Unsupported** and can't be imported.
- **Configure:** Pick which env-var target to pull (Production / Preview / Development), optionally exclude `VERCEL_*` variables, and toggle auto-deploy.
- **Imports:** The project's Git source (repo, branch, and **Root Directory**), build/install commands, environment variables, and custom domains (`*.vercel.app` hostnames are skipped). Builds then run through Railpack on the user's server.
- **Success summary** reports how many variables/domains were imported and warns when sensitive variables were skipped.

### Demo Video

https://github.com/user-attachments/assets/522a5742-f4d6-4206-954a-4c2a21a7bb0f


### Mapping

One Vercel **project → one Aeroplane project group** with a single Git service. Vercel has no "project contains multiple services" concept (each deployable app is its own Vercel project), so there's no multi-service checklist as Railway has.


### Testing

- `npm run typecheck` passes (client + server).
- Verified end-to-end against the live Vercel API: unsupported-project classification, team scope, env-target switching, custom-domain import + `*.vercel.app` skip, sensitive-variable skip, auto-deploy-off → idle service, bad-token error handling, and **Railway import still works** (regression).

### Notes/limitations

- **Sensitive** Vercel env vars cannot be read via the API, so their values aren't imported — the count is surfaced in the success summary for manual re-entry.
- A Vercel project maps to a single service; multi-app monorepos on Vercel are multiple Vercel projects, imported individually.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds “Import from Vercel” to migrate a Vercel project into a self‑hosted service, including Git source, env vars, build/install commands, and custom domains. Also normalizes Docker identifiers to handle mixed separators and prevent deploy failures.

- New Features
  - 5-step `VercelImportModal` (auth → select → configure → importing → success) with team scope, search, token remember option, and a success summary.
  - Options: pick env-var target (Production/Preview/Development), exclude `VERCEL_*`, and toggle auto-deploy.
  - Imports repo/branch/root dir, build/install commands, env vars, and custom domains; skips `*.vercel.app` hosts and surfaces a count for sensitive vars that must be re-entered.
  - Flags projects without a connected Git repo as Unsupported; adds an “Import Vercel” entry point on the Projects page.
  - Backend endpoints: `/api/integrations/vercel/{teams,projects,project-details,import}` with token + optional `teamId`.

- Bug Fixes
  - Normalize Docker identifiers by collapsing mixed separators, fixing deploys for IDs with sequences like `_-.`.

<sup>Written for commit 045c397a006683ce1cf4582e5ed094253f9edcb3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/xt42io/aeroplane/pull/7?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

