### PR TITLE
Add realtime server monitoring page

### DIFF
--- a/src/client/api.ts
+++ b/src/client/api.ts
@@ -477,6 +477,39 @@ export type ToolCheck = {
   detail: string;
 };
 
+export type MonitoringSnapshot = {
+  timestamp: string;
+  cpu: {
+    usagePercent: number;
+    cores: number;
+  };
+  memory: {
+    usedBytes: number;
+    totalBytes: number;
+  };
+  disk: {
+    usedBytes: number;
+    totalBytes: number;
+    mount: string;
+  } | null;
+  docker: {
+    available: boolean;
+    totalBytes: number;
+    images: number;
+    containers: number;
+    volumes: number;
+    buildCache: number;
+  };
+  blockIO: {
+    readBytes: number;
+    writeBytes: number;
+  };
+  networkIO: {
+    inBytes: number;
+    outBytes: number;
+  };
+};
+
 export type SystemUpdateCommit = {
   sha: string;
   shortSha: string;
@@ -709,6 +742,7 @@ export const api = {
       body: JSON.stringify(body)
     }),
   system: () => request<{ tools: ToolCheck[] }>("/api/system"),
+  monitoring: () => request<MonitoringSnapshot>("/api/system/monitoring"),
   frameworkIcons: () => request<{ icons: FrameworkIconAsset[] }>("/api/assets/framework-icons"),
   githubStatus: () => request<GitHubStatus>("/api/github/status"),
   githubRepos: (query = "") => request<{ repos: GitHubRepo[] }>(`/api/github/repos?q=${encodeURIComponent(query)}`),

--- a/src/client/pages/monitoring-page.tsx
+++ b/src/client/pages/monitoring-page.tsx
@@ -1,0 +1,438 @@
+import { Link } from "@tanstack/react-router";
+import {
+  ArrowDataTransferHorizontalIcon,
+  ArrowLeft01Icon,
+  ContainerIcon,
+  CpuIcon,
+  HardDriveIcon,
+  PulseRectangleIcon,
+  RamMemoryIcon,
+} from "@hugeicons/core-free-icons";
+import { useEffect, useRef, useState } from "react";
+import { type MonitoringSnapshot } from "../api";
+import { BrandMark } from "../components/ui/brand-mark";
+import { AppIcon } from "../components/ui/primitives";
+import { usePageTitle } from "../lib/page-title";
+
+const HISTORY_LENGTH = 60;
+const TEAL = "#4FB8B2";
+const PINK = "#E93D82";
+const AMBER = "#F5A524";
+const VIOLET = "#7871FF";
+
+type Series = number[];
+
+function pushSample(series: Series, value: number): Series {
+  const next = [...series, value];
+  return next.length > HISTORY_LENGTH ? next.slice(next.length - HISTORY_LENGTH) : next;
+}
+
+function formatBytes(bytes: number, fractionDigits = 2): string {
+  if (!Number.isFinite(bytes) || bytes <= 0) return "0 B";
+  const units = ["B", "KB", "MB", "GB", "TB"];
+  const exponent = Math.min(units.length - 1, Math.floor(Math.log(bytes) / Math.log(1024)));
+  const value = bytes / 1024 ** exponent;
+  return `${value.toFixed(exponent === 0 ? 0 : fractionDigits)} ${units[exponent]}`;
+}
+
+function bytesToMb(bytes: number): number {
+  return bytes / 1024 ** 2;
+}
+
+function Sparkline({
+  data,
+  color,
+  fill = true,
+  max,
+}: {
+  data: Series;
+  color: string;
+  fill?: boolean;
+  max?: number;
+}) {
+  const width = 600;
+  const height = 160;
+  if (data.length < 2) {
+    return (
+      <svg viewBox={`0 0 ${width} ${height}`} className="h-40 w-full" preserveAspectRatio="none">
+        <text x={width / 2} y={height / 2} textAnchor="middle" className="fill-zinc-600 font-mono text-[14px]">
+          collecting samples…
+        </text>
+      </svg>
+    );
+  }
+
+  const peak = max ?? Math.max(...data, 1);
+  const stepX = width / (HISTORY_LENGTH - 1);
+  const offset = (HISTORY_LENGTH - data.length) * stepX;
+  const points = data.map((value, index) => {
+    const x = offset + index * stepX;
+    const y = height - (Math.min(value, peak) / peak) * (height - 8) - 4;
+    return [x, y] as const;
+  });
+
+  const line = points.map(([x, y], index) => `${index === 0 ? "M" : "L"}${x.toFixed(1)},${y.toFixed(1)}`).join(" ");
+  const area = `${line} L${points.at(-1)![0].toFixed(1)},${height} L${points[0][0].toFixed(1)},${height} Z`;
+  const gradientId = `grad-${color.replace("#", "")}`;
+
+  return (
+    <svg viewBox={`0 0 ${width} ${height}`} className="h-40 w-full" preserveAspectRatio="none">
+      <defs>
+        <linearGradient id={gradientId} x1="0" y1="0" x2="0" y2="1">
+          <stop offset="0%" stopColor={color} stopOpacity="0.35" />
+          <stop offset="100%" stopColor={color} stopOpacity="0" />
+        </linearGradient>
+      </defs>
+      {[0.25, 0.5, 0.75].map((ratio) => (
+        <line
+          key={ratio}
+          x1={0}
+          x2={width}
+          y1={height * ratio}
+          y2={height * ratio}
+          stroke="rgba(255,255,255,0.05)"
+          strokeWidth={1}
+        />
+      ))}
+      {fill ? <path d={area} fill={`url(#${gradientId})`} /> : null}
+      <path d={line} fill="none" stroke={color} strokeWidth={2} strokeLinejoin="round" strokeLinecap="round" />
+    </svg>
+  );
+}
+
+function Donut({ segments, centerLabel, centerValue }: {
+  segments: Array<{ label: string; value: number; color: string }>;
+  centerLabel: string;
+  centerValue: string;
+}) {
+  const total = segments.reduce((sum, segment) => sum + segment.value, 0);
+  const radius = 70;
+  const stroke = 26;
+  const circumference = 2 * Math.PI * radius;
+  let consumed = 0;
+
+  return (
+    <div className="flex flex-col items-center gap-5">
+      <svg viewBox="0 0 180 180" className="h-44 w-44 -rotate-90">
+        <circle cx={90} cy={90} r={radius} fill="none" stroke="rgba(255,255,255,0.06)" strokeWidth={stroke} />
+        {total > 0
+          ? segments.map((segment) => {
+              const fraction = segment.value / total;
+              const dash = fraction * circumference;
+              const element = (
+                <circle
+                  key={segment.label}
+                  cx={90}
+                  cy={90}
+                  r={radius}
+                  fill="none"
+                  stroke={segment.color}
+                  strokeWidth={stroke}
+                  strokeDasharray={`${dash} ${circumference - dash}`}
+                  strokeDashoffset={-consumed}
+                />
+              );
+              consumed += dash;
+              return element;
+            })
+          : null}
+        <g className="rotate-90" transform="rotate(90 90 90)">
+          <text x={90} y={84} textAnchor="middle" className="fill-zinc-100 font-hero text-[20px]">
+            {centerValue}
+          </text>
+          <text x={90} y={104} textAnchor="middle" className="fill-zinc-500 font-mono text-[9px] uppercase tracking-[0.2em]">
+            {centerLabel}
+          </text>
+        </g>
+      </svg>
+      <div className="flex flex-wrap items-center justify-center gap-x-4 gap-y-2">
+        {segments.map((segment) => (
+          <div key={segment.label} className="inline-flex items-center gap-2 font-mono text-[11px] text-zinc-400">
+            <span className="h-2.5 w-2.5" style={{ backgroundColor: segment.color }} />
+            {segment.label}
+            <span className="text-zinc-600">{formatBytes(segment.value)}</span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function MeterBar({ ratio, color }: { ratio: number; color: string }) {
+  return (
+    <div className="h-2 w-full overflow-hidden bg-white/5">
+      <div
+        className="h-full transition-all duration-500"
+        style={{ width: `${Math.min(100, Math.max(0, ratio * 100))}%`, backgroundColor: color }}
+      />
+    </div>
+  );
+}
+
+function Card({
+  icon,
+  title,
+  meta,
+  children,
+}: {
+  icon: unknown;
+  title: string;
+  meta: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <section className="flex flex-col gap-4 border border-zinc-800/90 bg-zinc-950/60 p-5">
+      <div className="flex items-start justify-between gap-3">
+        <div className="flex items-center gap-3">
+          <div className="grid h-9 w-9 place-items-center border border-[#4FB8B2]/30 bg-[#4FB8B2]/10 text-[#4FB8B2]">
+            <AppIcon icon={icon} size={16} />
+          </div>
+          <div>
+            <div className="font-hero text-sm tracking-tight text-zinc-100">{title}</div>
+            <div className="font-mono text-[11px] text-zinc-500">{meta}</div>
+          </div>
+        </div>
+      </div>
+      {children}
+    </section>
+  );
+}
+
+function Legend({ items }: { items: Array<{ label: string; color: string }> }) {
+  return (
+    <div className="flex items-center justify-center gap-4">
+      {items.map((item) => (
+        <div key={item.label} className="inline-flex items-center gap-2 font-mono text-[11px] text-zinc-400">
+          <span className="h-2.5 w-2.5" style={{ backgroundColor: item.color }} />
+          {item.label}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export function MonitoringPage() {
+  usePageTitle("Monitoring");
+
+  const [snapshot, setSnapshot] = useState<MonitoringSnapshot | null>(null);
+  const [connected, setConnected] = useState(false);
+  const [error, setError] = useState("");
+
+  const [cpuHistory, setCpuHistory] = useState<Series>([]);
+  const [memHistory, setMemHistory] = useState<Series>([]);
+  const [diskHistory, setDiskHistory] = useState<Series>([]);
+  const [blockReadHistory, setBlockReadHistory] = useState<Series>([]);
+  const [blockWriteHistory, setBlockWriteHistory] = useState<Series>([]);
+  const [netInHistory, setNetInHistory] = useState<Series>([]);
+  const [netOutHistory, setNetOutHistory] = useState<Series>([]);
+
+  const lastBlock = useRef<{ read: number; write: number } | null>(null);
+  const lastNet = useRef<{ in: number; out: number } | null>(null);
+
+  useEffect(() => {
+    const events = new EventSource("/api/system/monitoring/stream");
+
+    events.addEventListener("sample", (event) => {
+      const sample = JSON.parse((event as MessageEvent).data) as MonitoringSnapshot;
+      setSnapshot(sample);
+      setConnected(true);
+      setError("");
+
+      setCpuHistory((current) => pushSample(current, sample.cpu.usagePercent));
+      setMemHistory((current) => pushSample(current, bytesToMb(sample.memory.usedBytes) / 1024));
+      if (sample.disk) {
+        setDiskHistory((current) => pushSample(current, bytesToMb(sample.disk!.usedBytes) / 1024));
+      }
+
+      // Block / network IO are cumulative totals; chart the per-interval delta in MB.
+      const block = { read: bytesToMb(sample.blockIO.readBytes), write: bytesToMb(sample.blockIO.writeBytes) };
+      if (lastBlock.current) {
+        setBlockReadHistory((current) => pushSample(current, Math.max(0, block.read - lastBlock.current!.read)));
+        setBlockWriteHistory((current) => pushSample(current, Math.max(0, block.write - lastBlock.current!.write)));
+      }
+      lastBlock.current = block;
+
+      const net = { in: bytesToMb(sample.networkIO.inBytes), out: bytesToMb(sample.networkIO.outBytes) };
+      if (lastNet.current) {
+        setNetInHistory((current) => pushSample(current, Math.max(0, net.in - lastNet.current!.in)));
+        setNetOutHistory((current) => pushSample(current, Math.max(0, net.out - lastNet.current!.out)));
+      }
+      lastNet.current = net;
+    });
+
+    events.addEventListener("status", (event) => {
+      const status = JSON.parse((event as MessageEvent).data) as { ok: boolean; detail?: string };
+      if (!status.ok) setError(status.detail ?? "Monitoring failed");
+    });
+
+    events.onerror = () => setConnected(false);
+
+    return () => events.close();
+  }, []);
+
+  const memRatio = snapshot ? snapshot.memory.usedBytes / snapshot.memory.totalBytes : 0;
+  const diskRatio = snapshot?.disk ? snapshot.disk.usedBytes / snapshot.disk.totalBytes : 0;
+  const blockPeak = Math.max(...blockReadHistory, ...blockWriteHistory, 1);
+  const netPeak = Math.max(...netInHistory, ...netOutHistory, 1);
+
+  return (
+    <main className="relative isolate min-h-dvh overflow-hidden bg-zinc-950 text-zinc-100">
+      <div aria-hidden className="hero-noise pointer-events-none absolute inset-0" />
+      <div
+        aria-hidden
+        className="pointer-events-none absolute inset-0 bg-[radial-gradient(ellipse_90%_60%_at_0%_0%,rgba(79,184,178,0.12),transparent),radial-gradient(ellipse_70%_50%_at_100%_100%,rgba(120,113,255,0.08),transparent)]"
+      />
+      <div
+        aria-hidden
+        className="pointer-events-none absolute inset-0 [background-image:linear-gradient(rgba(255,255,255,0.03)_1px,transparent_1px),linear-gradient(90deg,rgba(255,255,255,0.03)_1px,transparent_1px)] [background-size:72px_72px]"
+      />
+
+      <div className="relative z-10 mx-auto flex w-full max-w-6xl flex-col gap-8 px-5 pb-24 pt-14 sm:px-6 lg:px-10">
+        <header className="flex flex-wrap items-center justify-between gap-4 border-b border-zinc-800/90 pb-5">
+          <div className="flex items-center gap-3">
+            <div className="grid h-11 w-11 place-items-center border border-[#4FB8B2]/35 bg-[#4FB8B2]/10 text-[#4FB8B2]">
+              <BrandMark />
+            </div>
+            <div>
+              <div className="font-mono text-[10px] uppercase tracking-[0.28em] text-zinc-600">Aeroplane registry</div>
+              <div className="font-hero text-lg tracking-tight text-zinc-100">Monitoring</div>
+            </div>
+          </div>
+          <div className="flex items-center gap-3">
+            <div className="inline-flex items-center gap-2 border border-zinc-800 bg-zinc-900/50 px-3 py-1.5 font-mono text-[10px] uppercase tracking-[0.16em] text-zinc-400">
+              <span className={`h-2 w-2 rounded-full ${connected ? "bg-[#4FB8B2]" : "bg-zinc-600"}`} />
+              {connected ? "Live" : "Connecting"}
+            </div>
+            <Link
+              to="/"
+              className="inline-flex h-9 items-center justify-center gap-2 border border-zinc-800 bg-zinc-900/50 px-3 font-mono text-[10px] font-semibold uppercase tracking-[0.16em] text-zinc-300 transition-colors hover:bg-zinc-800"
+            >
+              <AppIcon icon={ArrowLeft01Icon} size={14} />
+              Projects
+            </Link>
+          </div>
+        </header>
+
+        <div>
+          <h1 className="font-hero text-2xl tracking-tight text-zinc-100">Server resources</h1>
+          <p className="mt-1 font-mono text-sm text-zinc-500">Watch the live usage of the machine running Aeroplane.</p>
+        </div>
+
+        {error ? (
+          <div className="border border-rose-500/35 bg-rose-950/30 px-4 py-3 font-mono text-xs text-rose-300">{error}</div>
+        ) : null}
+
+        <div className="grid gap-5 lg:grid-cols-2">
+          <Card
+            icon={CpuIcon}
+            title="CPU Usage"
+            meta={snapshot ? `${snapshot.cpu.usagePercent.toFixed(2)}% · ${snapshot.cpu.cores} cores` : "—"}
+          >
+            <MeterBar ratio={(snapshot?.cpu.usagePercent ?? 0) / 100} color={VIOLET} />
+            <Sparkline data={cpuHistory} color={VIOLET} max={100} />
+            <Legend items={[{ label: "CPU %", color: VIOLET }]} />
+          </Card>
+
+          <Card
+            icon={RamMemoryIcon}
+            title="Memory Usage"
+            meta={
+              snapshot
+                ? `${formatBytes(snapshot.memory.usedBytes)} / ${formatBytes(snapshot.memory.totalBytes)}`
+                : "—"
+            }
+          >
+            <MeterBar ratio={memRatio} color={PINK} />
+            <Sparkline
+              data={memHistory}
+              color={PINK}
+              max={snapshot ? bytesToMb(snapshot.memory.totalBytes) / 1024 : undefined}
+            />
+            <Legend items={[{ label: "Memory (GB)", color: PINK }]} />
+          </Card>
+
+          <Card
+            icon={HardDriveIcon}
+            title="Disk Space"
+            meta={
+              snapshot?.disk
+                ? `${formatBytes(snapshot.disk.usedBytes)} / ${formatBytes(snapshot.disk.totalBytes)}`
+                : "unavailable"
+            }
+          >
+            <MeterBar ratio={diskRatio} color={AMBER} />
+            <Sparkline
+              data={diskHistory}
+              color={AMBER}
+              max={snapshot?.disk ? bytesToMb(snapshot.disk.totalBytes) / 1024 : undefined}
+            />
+            <Legend items={[{ label: "Disk (GB)", color: AMBER }]} />
+          </Card>
+
+          <Card
+            icon={ContainerIcon}
+            title="Docker Disk Usage"
+            meta={snapshot ? `Total: ${formatBytes(snapshot.docker.totalBytes)}` : "—"}
+          >
+            <div className="flex flex-1 items-center justify-center py-2">
+              {snapshot && snapshot.docker.available ? (
+                <Donut
+                  centerLabel="Docker usage"
+                  centerValue={formatBytes(snapshot.docker.totalBytes)}
+                  segments={[
+                    { label: "Images", value: snapshot.docker.images, color: VIOLET },
+                    { label: "Containers", value: snapshot.docker.containers, color: PINK },
+                    { label: "Volumes", value: snapshot.docker.volumes, color: AMBER },
+                    { label: "Build cache", value: snapshot.docker.buildCache, color: TEAL },
+                  ]}
+                />
+              ) : (
+                <span className="font-mono text-xs text-zinc-600">Docker is unavailable.</span>
+              )}
+            </div>
+          </Card>
+
+          <Card
+            icon={PulseRectangleIcon}
+            title="Block I/O"
+            meta={
+              snapshot
+                ? `Read: ${formatBytes(snapshot.blockIO.readBytes)} · Write: ${formatBytes(snapshot.blockIO.writeBytes)}`
+                : "—"
+            }
+          >
+            <div className="relative h-40">
+              <div className="absolute inset-0">
+                <Sparkline data={blockReadHistory} color={VIOLET} fill={false} max={blockPeak} />
+              </div>
+              <div className="absolute inset-0">
+                <Sparkline data={blockWriteHistory} color={PINK} fill={false} max={blockPeak} />
+              </div>
+            </div>
+            <Legend items={[{ label: "Read (MB)", color: VIOLET }, { label: "Write (MB)", color: PINK }]} />
+          </Card>
+
+          <Card
+            icon={ArrowDataTransferHorizontalIcon}
+            title="Network I/O"
+            meta={
+              snapshot
+                ? `In: ${formatBytes(snapshot.networkIO.inBytes)} · Out: ${formatBytes(snapshot.networkIO.outBytes)}`
+                : "—"
+            }
+          >
+            <div className="relative h-40">
+              <div className="absolute inset-0">
+                <Sparkline data={netInHistory} color={VIOLET} fill={false} max={netPeak} />
+              </div>
+              <div className="absolute inset-0">
+                <Sparkline data={netOutHistory} color={PINK} fill={false} max={netPeak} />
+              </div>
+            </div>
+            <Legend items={[{ label: "In (MB)", color: VIOLET }, { label: "Out (MB)", color: PINK }]} />
+          </Card>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/src/client/pages/projects-page.tsx
+++ b/src/client/pages/projects-page.tsx
@@ -1,5 +1,5 @@
-import { useNavigate } from "@tanstack/react-router";
-import { AddSquareIcon, FolderCodeIcon } from "@hugeicons/core-free-icons";
+import { Link, useNavigate } from "@tanstack/react-router";
+import { AddSquareIcon, Activity01Icon, FolderCodeIcon } from "@hugeicons/core-free-icons";
 import { startTransition, useCallback, useEffect, useState } from "react";
 import {
   api,
@@ -194,6 +194,15 @@ export function ProjectsPage() {
                 <div className="hidden sm:block">
                   <SystemHealthPill tools={tools} />
                 </div>
+              ) : null}
+              {owner ? (
+                <Link
+                  to="/monitoring"
+                  className="inline-flex h-9 items-center justify-center gap-2 border border-zinc-800 bg-zinc-900/50 px-3 font-mono text-[10px] font-semibold uppercase tracking-[0.16em] text-zinc-300 transition-colors hover:bg-zinc-800"
+                >
+                  <AppIcon icon={Activity01Icon} size={14} />
+                  <span className="hidden md:inline">Monitoring</span>
+                </Link>
               ) : null}
               <button
                 type="button"

--- a/src/client/routeTree.gen.ts
+++ b/src/client/routeTree.gen.ts
@@ -10,6 +10,7 @@
 
 import { Route as rootRouteImport } from './routes/__root'
 import { Route as SvgsRouteImport } from './routes/svgs'
+import { Route as MonitoringRouteImport } from './routes/monitoring'
 import { Route as LoginRouteImport } from './routes/login'
 import { Route as ProjectSlugRouteImport } from './routes/$projectSlug'
 import { Route as IndexRouteImport } from './routes/index'
@@ -23,6 +24,11 @@ import { Route as ProjectSlugServiceSlugServiceTabRouteImport } from './routes/$
 const SvgsRoute = SvgsRouteImport.update({
   id: '/svgs',
   path: '/svgs',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const MonitoringRoute = MonitoringRouteImport.update({
+  id: '/monitoring',
+  path: '/monitoring',
   getParentRoute: () => rootRouteImport,
 } as any)
 const LoginRoute = LoginRouteImport.update({
@@ -77,6 +83,7 @@ export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
   '/$projectSlug': typeof ProjectSlugRouteWithChildren
   '/login': typeof LoginRoute
+  '/monitoring': typeof MonitoringRoute
   '/svgs': typeof SvgsRoute
   '/$projectSlug/$serviceSlug': typeof ProjectSlugServiceSlugRouteWithChildren
   '/onboarding/success': typeof OnboardingSuccessRoute
@@ -88,6 +95,7 @@ export interface FileRoutesByFullPath {
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
   '/login': typeof LoginRoute
+  '/monitoring': typeof MonitoringRoute
   '/svgs': typeof SvgsRoute
   '/onboarding/success': typeof OnboardingSuccessRoute
   '/$projectSlug': typeof ProjectSlugIndexRoute
@@ -100,6 +108,7 @@ export interface FileRoutesById {
   '/': typeof IndexRoute
   '/$projectSlug': typeof ProjectSlugRouteWithChildren
   '/login': typeof LoginRoute
+  '/monitoring': typeof MonitoringRoute
   '/svgs': typeof SvgsRoute
   '/$projectSlug/$serviceSlug': typeof ProjectSlugServiceSlugRouteWithChildren
   '/onboarding/success': typeof OnboardingSuccessRoute
@@ -114,6 +123,7 @@ export interface FileRouteTypes {
     | '/'
     | '/$projectSlug'
     | '/login'
+    | '/monitoring'
     | '/svgs'
     | '/$projectSlug/$serviceSlug'
     | '/onboarding/success'
@@ -125,6 +135,7 @@ export interface FileRouteTypes {
   to:
     | '/'
     | '/login'
+    | '/monitoring'
     | '/svgs'
     | '/onboarding/success'
     | '/$projectSlug'
@@ -136,6 +147,7 @@ export interface FileRouteTypes {
     | '/'
     | '/$projectSlug'
     | '/login'
+    | '/monitoring'
     | '/svgs'
     | '/$projectSlug/$serviceSlug'
     | '/onboarding/success'
@@ -149,6 +161,7 @@ export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
   ProjectSlugRoute: typeof ProjectSlugRouteWithChildren
   LoginRoute: typeof LoginRoute
+  MonitoringRoute: typeof MonitoringRoute
   SvgsRoute: typeof SvgsRoute
   OnboardingSuccessRoute: typeof OnboardingSuccessRoute
   OnboardingIndexRoute: typeof OnboardingIndexRoute
@@ -161,6 +174,13 @@ declare module '@tanstack/react-router' {
       path: '/svgs'
       fullPath: '/svgs'
       preLoaderRoute: typeof SvgsRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/monitoring': {
+      id: '/monitoring'
+      path: '/monitoring'
+      fullPath: '/monitoring'
+      preLoaderRoute: typeof MonitoringRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/login': {
@@ -264,6 +284,7 @@ const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   ProjectSlugRoute: ProjectSlugRouteWithChildren,
   LoginRoute: LoginRoute,
+  MonitoringRoute: MonitoringRoute,
   SvgsRoute: SvgsRoute,
   OnboardingSuccessRoute: OnboardingSuccessRoute,
   OnboardingIndexRoute: OnboardingIndexRoute,

--- a/src/client/routes/monitoring.tsx
+++ b/src/client/routes/monitoring.tsx
@@ -1,0 +1,10 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { MonitoringPage } from "../pages/monitoring-page";
+
+export const Route = createFileRoute("/monitoring")({
+  component: MonitoringRouteComponent
+});
+
+function MonitoringRouteComponent() {
+  return <MonitoringPage />;
+}

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -51,6 +51,7 @@ import {
 } from "./schema.js";
 import { getSystemChecks } from "./system.js";
 import { getSystemMaintenanceInfo, maintenanceCleanupTargets, runSystemMaintenanceCleanup } from "./system-maintenance.js";
+import { collectMonitoringSnapshot } from "./monitoring.js";
 import { writeAndReloadCaddy } from "./caddy.js";
 import { databaseConnectionEnvSuggestionsForProject, databaseConnectionEnvSuggestionsForService, syncProjectDatabaseConnectionEnv } from "./database-service-linker.js";
 import { createUniqueSlug } from "../shared/slug.js";
@@ -1350,6 +1351,8 @@ app.use("/api/system/updates", requireOwnerSessionAccessMiddleware);
 app.use("/api/system/updates/*", requireOwnerSessionAccessMiddleware);
 app.use("/api/system/maintenance", requireOwnerSessionAccessMiddleware);
 app.use("/api/system/maintenance/*", requireOwnerSessionAccessMiddleware);
+app.use("/api/system/monitoring", requireOwnerSessionAccessMiddleware);
+app.use("/api/system/monitoring/*", requireOwnerSessionAccessMiddleware);
 app.use("/api/system/migration/*", requireOwnerSessionAccessMiddleware);
 app.use("/api/system/users", requireOwnerSessionAccessMiddleware);
 app.use("/api/system/users/*", requireOwnerSessionAccessMiddleware);
@@ -1386,6 +1389,62 @@ app.get("/api/system", async (c) => {
 });
 
 app.get("/api/system/maintenance", async (c) => c.json(await getSystemMaintenanceInfo()));
+
+app.get("/api/system/monitoring", async (c) => c.json(await collectMonitoringSnapshot()));
+
+app.get("/api/system/monitoring/stream", (c) => {
+  const encoder = new TextEncoder();
+
+  return new Response(
+    new ReadableStream({
+      start(controller) {
+        let closed = false;
+        const write = (event: string, data: unknown) => {
+          if (closed) return;
+          try {
+            controller.enqueue(encoder.encode(`event: ${event}\ndata: ${JSON.stringify(data)}\n\n`));
+          } catch {
+            closed = true;
+          }
+        };
+
+        let running = false;
+        const tick = async () => {
+          if (closed || running) return;
+          running = true;
+          try {
+            write("sample", await collectMonitoringSnapshot());
+          } catch (error) {
+            write("status", { ok: false, detail: error instanceof Error ? error.message : "Monitoring failed" });
+          } finally {
+            running = false;
+          }
+        };
+
+        void tick();
+        const interval = setInterval(() => void tick(), 2000);
+
+        c.req.raw.signal.addEventListener("abort", () => {
+          if (closed) return;
+          closed = true;
+          clearInterval(interval);
+          try {
+            controller.close();
+          } catch {
+            // Already closed.
+          }
+        });
+      }
+    }),
+    {
+      headers: {
+        "Content-Type": "text/event-stream",
+        "Cache-Control": "no-cache, no-transform",
+        Connection: "keep-alive"
+      }
+    }
+  );
+});
 
 app.post("/api/system/maintenance/cleanup", async (c) => {
   const body = maintenanceCleanupSchema.safeParse(await c.req.json());

--- a/src/server/monitoring.ts
+++ b/src/server/monitoring.ts
@@ -1,0 +1,221 @@
+import { spawn } from "node:child_process";
+import { cpus, freemem, totalmem } from "node:os";
+
+export type MonitoringSnapshot = {
+  timestamp: string;
+  cpu: {
+    usagePercent: number;
+    cores: number;
+  };
+  memory: {
+    usedBytes: number;
+    totalBytes: number;
+  };
+  disk: {
+    usedBytes: number;
+    totalBytes: number;
+    mount: string;
+  } | null;
+  docker: {
+    available: boolean;
+    totalBytes: number;
+    images: number;
+    containers: number;
+    volumes: number;
+    buildCache: number;
+  };
+  blockIO: {
+    readBytes: number;
+    writeBytes: number;
+  };
+  networkIO: {
+    inBytes: number;
+    outBytes: number;
+  };
+};
+
+type CommandResult = { ok: boolean; output: string };
+
+function runCommand(command: string, args: string[], timeoutMs = 15000): Promise<CommandResult> {
+  return new Promise((resolveCommand) => {
+    const child = spawn(command, args, { stdio: ["ignore", "pipe", "pipe"] });
+    let output = "";
+    let settled = false;
+
+    const finish = (result: CommandResult) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolveCommand(result);
+    };
+
+    const timer = setTimeout(() => {
+      child.kill("SIGTERM");
+      finish({ ok: false, output });
+    }, timeoutMs);
+
+    child.stdout.on("data", (chunk: Buffer) => {
+      output += chunk.toString();
+    });
+    child.stderr.on("data", (chunk: Buffer) => {
+      output += chunk.toString();
+    });
+    child.on("error", () => finish({ ok: false, output }));
+    child.on("close", (code) => finish({ ok: code === 0, output }));
+  });
+}
+
+function parseSizeToBytes(value: string): number {
+  const token = value.trim().split(/\s+/)[0]?.replace(/,/g, "") ?? "";
+  const match = token.match(/^([\d.]+)\s*([a-z]+)?$/i);
+  if (!match) return 0;
+
+  const amount = Number(match[1]);
+  if (!Number.isFinite(amount)) return 0;
+
+  const unit = (match[2] ?? "b").toLowerCase();
+  const multipliers: Record<string, number> = {
+    b: 1,
+    kb: 1000,
+    k: 1000,
+    kib: 1024,
+    mb: 1000 ** 2,
+    m: 1000 ** 2,
+    mib: 1024 ** 2,
+    gb: 1000 ** 3,
+    g: 1000 ** 3,
+    gib: 1024 ** 3,
+    tb: 1000 ** 4,
+    t: 1000 ** 4,
+    tib: 1024 ** 4
+  };
+
+  return Math.round(amount * (multipliers[unit] ?? 1));
+}
+
+function cpuTimes() {
+  let idle = 0;
+  let total = 0;
+  for (const cpu of cpus()) {
+    idle += cpu.times.idle;
+    total += cpu.times.user + cpu.times.nice + cpu.times.sys + cpu.times.idle + cpu.times.irq;
+  }
+  return { idle, total };
+}
+
+async function sampleCpuUsage(sampleMs = 250): Promise<number> {
+  const start = cpuTimes();
+  await new Promise((r) => setTimeout(r, sampleMs));
+  const end = cpuTimes();
+
+  const totalDelta = end.total - start.total;
+  const idleDelta = end.idle - start.idle;
+  if (totalDelta <= 0) return 0;
+
+  const usage = (1 - idleDelta / totalDelta) * 100;
+  return Math.min(100, Math.max(0, Math.round(usage * 100) / 100));
+}
+
+async function getDiskMetric(): Promise<MonitoringSnapshot["disk"]> {
+  const result = await runCommand("df", ["-P", "-B1", "/"], 10000);
+  if (!result.ok) return null;
+
+  const lines = result.output.trim().split("\n").filter(Boolean);
+  if (lines.length < 2) return null;
+
+  const parts = lines[1].trim().split(/\s+/);
+  if (parts.length < 6) return null;
+
+  const totalBytes = Number(parts[1]);
+  const usedBytes = Number(parts[2]);
+  if (![totalBytes, usedBytes].every(Number.isFinite)) return null;
+
+  return { totalBytes, usedBytes, mount: parts.slice(5).join(" ") };
+}
+
+async function getDockerDiskMetric(): Promise<MonitoringSnapshot["docker"]> {
+  const empty = { available: false, totalBytes: 0, images: 0, containers: 0, volumes: 0, buildCache: 0 };
+  const result = await runCommand("docker", [
+    "system",
+    "df",
+    "--format",
+    "{{.Type}}\t{{.Size}}"
+  ]);
+  if (!result.ok) return empty;
+
+  let images = 0;
+  let containers = 0;
+  let volumes = 0;
+  let buildCache = 0;
+
+  for (const line of result.output.split("\n")) {
+    const [type, size] = line.split("\t");
+    if (!type || !size) continue;
+    const bytes = parseSizeToBytes(size);
+    const normalized = type.trim().toLowerCase();
+    if (normalized.startsWith("images")) images += bytes;
+    else if (normalized.startsWith("containers")) containers += bytes;
+    else if (normalized.startsWith("local volumes") || normalized.startsWith("volumes")) volumes += bytes;
+    else if (normalized.startsWith("build cache")) buildCache += bytes;
+  }
+
+  return {
+    available: true,
+    images,
+    containers,
+    volumes,
+    buildCache,
+    totalBytes: images + containers + volumes + buildCache
+  };
+}
+
+async function getContainerIO(): Promise<{ blockIO: MonitoringSnapshot["blockIO"]; networkIO: MonitoringSnapshot["networkIO"] }> {
+  const result = await runCommand("docker", [
+    "stats",
+    "--no-stream",
+    "--format",
+    "{{.BlockIO}}\t{{.NetIO}}"
+  ]);
+
+  const blockIO = { readBytes: 0, writeBytes: 0 };
+  const networkIO = { inBytes: 0, outBytes: 0 };
+  if (!result.ok) return { blockIO, networkIO };
+
+  for (const line of result.output.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    const [block, net] = trimmed.split("\t");
+    if (block) {
+      const [read, write] = block.split("/");
+      blockIO.readBytes += parseSizeToBytes(read ?? "");
+      blockIO.writeBytes += parseSizeToBytes(write ?? "");
+    }
+    if (net) {
+      const [rx, tx] = net.split("/");
+      networkIO.inBytes += parseSizeToBytes(rx ?? "");
+      networkIO.outBytes += parseSizeToBytes(tx ?? "");
+    }
+  }
+
+  return { blockIO, networkIO };
+}
+
+export async function collectMonitoringSnapshot(): Promise<MonitoringSnapshot> {
+  const [usagePercent, disk, docker, io] = await Promise.all([
+    sampleCpuUsage(),
+    getDiskMetric(),
+    getDockerDiskMetric(),
+    getContainerIO()
+  ]);
+
+  const total = totalmem();
+  return {
+    timestamp: new Date().toISOString(),
+    cpu: { usagePercent, cores: cpus().length },
+    memory: { usedBytes: total - freemem(), totalBytes: total },
+    disk,
+    docker,
+    blockIO: io.blockIO,
+    networkIO: io.networkIO
+  };
+}


### PR DESCRIPTION
## Summary

Adds a realtime server monitoring view to Aeroplane, modeled on Dokploy/Coolify's monitoring dashboards. It shows live usage of the machine running Aeroplane.

Reachable from a new owner-only **Monitoring** link in the projects header (`/monitoring`).

## What it tracks

- **CPU Usage** — sampled CPU % across cores
- **Memory Usage** — used / total
- **Disk Space** — root filesystem via `df`
- **Docker Disk Usage** — images / containers / volumes / build cache via `docker system df` (donut chart)
- **Block I/O** — aggregated container read/write via `docker stats`
- **Network I/O** — aggregated container in/out via `docker stats`

## Implementation

- `src/server/monitoring.ts` — `collectMonitoringSnapshot()` gathers all metrics with safe parsing/fallbacks (returns zeros/null when Docker or `df` is unavailable).
- `src/server/index.ts` — owner-only endpoints:
  - `GET /api/system/monitoring` — one-shot snapshot
  - `GET /api/system/monitoring/stream` — SSE, pushes a fresh snapshot every 2s (mirrors the existing deployment/runtime log-stream pattern, with abort cleanup)
- `src/client/pages/monitoring-page.tsx` + `src/client/routes/monitoring.tsx` — consumes the SSE stream and renders live SVG sparklines, usage meters, and a Docker-usage donut. Block/Network I/O are charted as per-interval deltas since the docker values are cumulative. No new dependencies — charts are hand-rolled SVG to match the existing dark zinc/mono theme.
- `src/client/api.ts` — `MonitoringSnapshot` type + `api.monitoring()`.

## Testing

- `npm run typecheck` passes
- `vite build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a real-time, owner-only Monitoring page that streams server metrics via SSE and visualizes them with live charts. This gives owners quick visibility into the Aeroplane host’s CPU, memory, disk, Docker usage, and container I/O.

- **New Features**
  - Owner-only Monitoring page at "/monitoring" with a new header link from Projects.
  - Endpoints: GET "/api/system/monitoring" (snapshot) and GET "/api/system/monitoring/stream" (SSE every 2s).
  - Metrics: CPU %/cores, memory used/total, root disk used/total, Docker disk breakdown (images/containers/volumes/build cache), aggregated container Block I/O and Network I/O (charted as per-interval deltas).
  - Safe fallbacks when "docker" or "df" are unavailable (returns zeros/null); owner access enforced.
  - UI uses lightweight SVG sparklines/meters and a donut chart; no new dependencies.

<sup>Written for commit d1cedd88a7e9455912d7693455c772c4b25a6c5b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/xt42io/aeroplane/pull/8?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

