### PR TITLE
Keep selected deployment on refresh

### DIFF
--- a/src/client/features/services/service-page-shell.tsx
+++ b/src/client/features/services/service-page-shell.tsx
@@ -209,9 +209,9 @@ export function ServicePageShell({
       startTransition(() => {
         setOverview(result);
         setActiveDeploymentId((current) => {
+          if (current && result.deployments.some((deployment) => deployment.id === current)) return current;
           const pendingDeployment = result.deployments.find((deployment) => deploymentIsPending(deployment.status));
           if (pendingDeployment) return pendingDeployment.id;
-          if (current && result.deployments.some((deployment) => deployment.id === current)) return current;
           return result.deployments[0]?.id ?? null;
         });
         if (shouldSyncSettings) setSettings(settingsFromService(result.service));


### PR DESCRIPTION
## Summary

Fixes the deployments detail view so periodic overview refreshes preserve the deployment the user is inspecting when that deployment still exists.

## Root cause

The refresh selection logic preferred any pending deployment before checking whether the current deployment was still present. When a newer build appeared or remained pending, the detail view switched away from the selected failed build, which also closed the "What happened?" modal.

## Impact

Users can keep the failure explanation modal open while a newer/latest build starts or refreshes in the background.

## Validation

Not run, per project instruction to avoid build/browser tests for small code changes unless needed.

Fixes #5

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves the selected deployment during overview refreshes when it still exists, instead of switching to a pending build. This keeps the "What happened?" modal open while newer builds start in the background.

<sup>Written for commit f83f44e8c0759d7d735bda75250aec2fa2decce0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/xt42io/aeroplane/pull/18?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

