### PR TITLE
Fix AI explanation schema

### DIFF
--- a/src/server/deployment-failure-ai.ts
+++ b/src/server/deployment-failure-ai.ts
@@ -15,8 +15,8 @@ const deploymentFailureExplanationSchema = z.object({
   cause: z.string().min(1),
   suggestedFix: z.string().min(1),
   confidence: z.enum(["low", "medium", "high"]),
-  commands: z.array(z.string()).max(5).default([]),
-  relatedLogLines: z.array(z.string()).max(8).default([])
+  commands: z.array(z.string()).max(5),
+  relatedLogLines: z.array(z.string()).max(8)
 });
 
 export type DeploymentFailureExplanation = z.infer<typeof deploymentFailureExplanationSchema> & {


### PR DESCRIPTION
## Summary

Fixes the structured output schema used by the deployment failure explanation flow.

## Root cause

The schema included `commands` and `relatedLogLines` as properties with Zod defaults. That made them optional in the generated JSON schema, but OpenAI strict structured outputs require every property to be listed in `required`. GPT-5.2 rejected the request before generation.

## Impact

The "What happened?" AI explanation can run with GPT-5.2 while still allowing empty arrays for commands or related log lines.

## Validation

Not run, per project instruction to avoid build/browser tests for small code changes unless needed.

Fixes #12

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Require `commands` and `relatedLogLines` in the deployment failure explanation schema to satisfy GPT-5.2 strict structured outputs and prevent request rejection. Arrays can still be empty, but they must be present.

<sup>Written for commit 015b2f5d4b516ab386f5972d3baa72df4a340ba1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/xt42io/aeroplane/pull/19?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

