### PR TITLE
Add persistent volumes for application services

### DIFF
--- a/src/client/api.ts
+++ b/src/client/api.ts
@@ -36,6 +36,7 @@ export type Service = {
   staticOutput: null | string;
   buildMethod: ServiceBuildMethod;
   dockerfilePath: null | string;
+  persistentVolumePath: null | string;
   detectedBuildMethod: null | "railpack" | "dockerfile";
   runtimeMode: ServiceRuntimeMode;
   internalPort: number;

--- a/src/client/components/modals/docker-image-service-settings-panel.tsx
+++ b/src/client/components/modals/docker-image-service-settings-panel.tsx
@@ -11,6 +11,7 @@ type DockerImageServiceSettings = {
   dockerImage: string;
   runtimeMode: "web" | "worker";
   internalPort: number;
+  persistentVolumePath: string;
 };
 
 export function DockerImageServiceSettingsPanel({
@@ -62,6 +63,21 @@ export function DockerImageServiceSettingsPanel({
         ) : (
           <p className="mt-2 text-xs text-zinc-500">Private images use the host Docker daemon's registry login.</p>
         )}
+      </div>
+      <div className="xl:col-span-2">
+        <label htmlFor="docker-persistent-volume-path" className={settingsLabelClass}>Persistent volume path</label>
+        <FormInput
+          id="docker-persistent-volume-path"
+          name="persistentVolumePath"
+          value={settings.persistentVolumePath}
+          onChange={(event) => onChange({ persistentVolumePath: event.target.value })}
+          placeholder="/data"
+          variant="monochrome"
+          className={`${settingsInputClass} font-mono`}
+        />
+        <p className="mt-2 text-xs leading-5 text-zinc-500">
+          Mounts a service-specific Docker volume at this absolute container path. Stateful redeployments briefly stop the previous container to protect writable data.
+        </p>
       </div>
     </>
   );

--- a/src/client/components/modals/maintenance-cleanup-card.tsx
+++ b/src/client/components/modals/maintenance-cleanup-card.tsx
@@ -72,7 +72,7 @@ export function MaintenanceCleanupCard({
 
         {confirmVolumes ? (
           <div className="border-l-2 border-rose-400 bg-rose-400/10 p-3">
-            <p className="text-xs leading-relaxed text-rose-100">Delete unused Docker volumes? This will not remove attached volumes, but it can delete old database data left behind by removed containers.</p>
+            <p className="text-xs leading-relaxed text-rose-100">Delete unused Docker volumes? This will not remove attached volumes, but it can delete persistent service or database data left behind by removed containers.</p>
             <div className="mt-3 flex gap-2">
               <button type="button" className="inline-flex h-9 items-center justify-center gap-2 border border-rose-400/50 px-3 text-sm text-rose-200 transition hover:bg-rose-400/10 disabled:opacity-50" onClick={() => onRunCleanup("volumes", ["docker-volumes"])} disabled={Boolean(cleanupMode)}>
                 <AppIcon icon={Delete02Icon} size={14} className={cleanupMode === "volumes" ? "animate-spin" : ""} />

--- a/src/client/components/modals/maintenance-utils.ts
+++ b/src/client/components/modals/maintenance-utils.ts
@@ -55,7 +55,7 @@ export function dockerReclaimableDetail(info: SystemMaintenanceInfo | null) {
   }
 
   if (rowType.includes("volume")) {
-    return `${amount} is volume data. Volume cleanup is separate because old database data can live there.`;
+    return `${amount} is volume data. Volume cleanup is separate because persistent service or database data can live there.`;
   }
 
   if (rowType.includes("build")) {

--- a/src/client/features/services/application-service-settings-panel.tsx
+++ b/src/client/features/services/application-service-settings-panel.tsx
@@ -176,6 +176,25 @@ export function ApplicationServiceSettingsPanel({
         </div>
       ) : null}
 
+      {!settings.staticOutput ? (
+        <div className="xl:col-span-2">
+          <FieldLabel>Persistent volume path</FieldLabel>
+          <FormInput
+            name="persistentVolumePath"
+            value={settings.persistentVolumePath}
+            onChange={(event) => onChange({ persistentVolumePath: event.target.value })}
+            placeholder="/data"
+            variant="monochrome"
+            className={`${inputClass} font-mono`}
+          />
+          <p className="mt-2 text-xs leading-5 text-zinc-500">
+            Mounts a service-specific Docker volume at this absolute container path. Stateful redeployments briefly stop the previous container to protect writable data.
+          </p>
+        </div>
+      ) : (
+        <input type="hidden" name="persistentVolumePath" value="" />
+      )}
+
       <div className="xl:col-span-2">
         <FieldLabel>Build method</FieldLabel>
         <BuildMethodControl value={settings.buildMethod} onChange={(buildMethod) => onChange({ buildMethod })} />

--- a/src/client/features/services/service-page-shell.tsx
+++ b/src/client/features/services/service-page-shell.tsx
@@ -85,6 +85,7 @@ function settingsFromService(service: Service): ServiceSettingsState {
     staticOutput: service.staticOutput ?? "",
     buildMethod: service.buildMethod,
     dockerfilePath: service.dockerfilePath ?? "",
+    persistentVolumePath: service.persistentVolumePath ?? "",
     runtimeMode: service.runtimeMode,
     internalPort: service.internalPort,
     databasePublicEnabled: service.databasePublicEnabled,
@@ -156,6 +157,7 @@ export function ServicePageShell({
     staticOutput: "",
     buildMethod: "auto" as "auto" | "railpack" | "dockerfile",
     dockerfilePath: "",
+    persistentVolumePath: "",
     runtimeMode: "web" as "web" | "worker",
     internalPort: 8080,
     databasePublicEnabled: true,
@@ -467,6 +469,7 @@ export function ServicePageShell({
       startCommand: formValue(form, "startCommand", settings.startCommand),
       staticOutput: formValue(form, "staticOutput", settings.staticOutput),
       dockerfilePath: formValue(form, "dockerfilePath", settings.dockerfilePath),
+      persistentVolumePath: formValue(form, "persistentVolumePath", settings.persistentVolumePath),
       internalPort: formNumberValue(form, "internalPort", settings.internalPort),
       databasePublicHostname: formValue(form, "databasePublicHostname", settings.databasePublicHostname)
     };
@@ -497,6 +500,7 @@ export function ServicePageShell({
         staticOutput: isDatabase || isDockerImage || isFunction ? undefined : textOrNull(submittedSettings.staticOutput),
         buildMethod: isDatabase || isDockerImage || isFunction ? undefined : submittedSettings.buildMethod,
         dockerfilePath: isDatabase || isDockerImage || isFunction ? undefined : textOrNull(submittedSettings.dockerfilePath),
+        persistentVolumePath: isDatabase || isFunction || submittedSettings.staticOutput ? null : textOrNull(submittedSettings.persistentVolumePath),
         runtimeMode: isDatabase ? undefined : submittedSettings.runtimeMode,
         internalPort: Number(submittedSettings.internalPort),
         databasePublicEnabled: isDatabase ? true : undefined,

--- a/src/client/features/services/service-settings-state.ts
+++ b/src/client/features/services/service-settings-state.ts
@@ -12,6 +12,7 @@ export type ServiceSettingsState = {
   staticOutput: string;
   buildMethod: "auto" | "railpack" | "dockerfile";
   dockerfilePath: string;
+  persistentVolumePath: string;
   runtimeMode: "web" | "worker";
   internalPort: number;
   databasePublicEnabled: boolean;

--- a/src/server/application-volume.ts
+++ b/src/server/application-volume.ts
@@ -1,0 +1,26 @@
+import type { Service } from "./schema.js";
+
+function safeDockerIdentifier(value: string, fallback: string) {
+  return value.toLowerCase().replace(/[^a-z0-9_.-]+/g, "-").replace(/^[^a-z0-9]+|[^a-z0-9]+$/g, "") || fallback;
+}
+
+export function applicationDataVolumeName(serviceId: string) {
+  return `aeroplane-app-data-${safeDockerIdentifier(serviceId, "service")}`;
+}
+
+export function applicationDataVolumeArg(serviceId: string, containerPath: string) {
+  return `${applicationDataVolumeName(serviceId)}:${containerPath}`;
+}
+
+export function isValidApplicationVolumePath(value: string) {
+  return value.startsWith("/")
+    && value !== "/"
+    && !value.includes(":")
+    && !value.includes("\\")
+    && value.split("/").slice(1).every((segment) => segment !== "" && segment !== "." && segment !== "..");
+}
+
+export function applicationDataVolumeDockerArgs(service: Pick<Service, "id" | "persistentVolumePath">) {
+  const containerPath = service.persistentVolumePath?.trim();
+  return containerPath ? ["-v", applicationDataVolumeArg(service.id, containerPath)] : [];
+}

--- a/src/server/db.ts
+++ b/src/server/db.ts
@@ -45,6 +45,7 @@ CREATE TABLE IF NOT EXISTS projects (
   static_output TEXT,
   build_method TEXT NOT NULL DEFAULT 'auto',
   dockerfile_path TEXT,
+  persistent_volume_path TEXT,
   detected_build_method TEXT,
   runtime_mode TEXT NOT NULL DEFAULT 'web',
   internal_port INTEGER NOT NULL,
@@ -267,6 +268,10 @@ if (!hasColumn("projects", "build_method")) {
 
 if (!hasColumn("projects", "dockerfile_path")) {
   sqlite.exec("ALTER TABLE projects ADD COLUMN dockerfile_path TEXT");
+}
+
+if (!hasColumn("projects", "persistent_volume_path")) {
+  sqlite.exec("ALTER TABLE projects ADD COLUMN persistent_volume_path TEXT");
 }
 
 if (!hasColumn("projects", "detected_build_method")) {

--- a/src/server/deploy.ts
+++ b/src/server/deploy.ts
@@ -40,6 +40,7 @@ import { isWorkerService } from "../shared/service-runtime.js";
 import { isFunctionService } from "../shared/service-functions.js";
 import { functionRuntimeLabel, writeFunctionDeploymentProject } from "./service-functions.js";
 import { prepareTanStackStartRuntime } from "./tanstack-start-runtime.js";
+import { applicationDataVolumeDockerArgs } from "./application-volume.js";
 
 type RunOptions = {
   cwd?: string;
@@ -383,6 +384,30 @@ function currentActivePortForService(serviceId: string, fallback: number | null)
   return current ? current.activePort : fallback;
 }
 
+async function stopExistingContainerForVolumeRollout({
+  service,
+  containerName,
+  deploymentId,
+  secrets
+}: {
+  service: Pick<Service, "persistentVolumePath">;
+  containerName: string;
+  deploymentId: string;
+  secrets: string[];
+}) {
+  if (!service.persistentVolumePath) return false;
+
+  const existingState = await getContainerState(containerName);
+  if (!existingState?.running && !existingState?.restarting) {
+    appendDeploymentLog(deploymentId, `No previous container named ${containerName} was running.`);
+    return false;
+  }
+
+  appendDeploymentLog(deploymentId, "Stopping the previous container before attaching its persistent volume to the replacement.");
+  await runCommand("docker", ["stop", containerName], deploymentId, { redact: secrets });
+  return true;
+}
+
 async function rollbackFailedWebRollout({
   deploymentId,
   serviceId,
@@ -390,6 +415,7 @@ async function rollbackFailedWebRollout({
   shouldRestoreActivePort,
   tempContainerName,
   shouldRemoveTempContainer,
+  stoppedContainerName,
   secrets
 }: {
   deploymentId: string;
@@ -398,8 +424,27 @@ async function rollbackFailedWebRollout({
   shouldRestoreActivePort: boolean;
   tempContainerName: string | null;
   shouldRemoveTempContainer: boolean;
+  stoppedContainerName?: string | null;
   secrets: string[];
 }) {
+  if (tempContainerName && shouldRemoveTempContainer) {
+    await removeDeploymentContainer({
+      containerName: tempContainerName,
+      log: (line, stream = "system") => appendDeploymentLog(deploymentId, line, stream, secrets),
+      runBufferedDocker: (args) => runBufferedCommand("docker", args)
+    });
+  }
+
+  if (stoppedContainerName) {
+    try {
+      appendDeploymentLog(deploymentId, `Restarting previous stateful container ${stoppedContainerName} after failed rollout.`, "stderr", secrets);
+      await runCommand("docker", ["start", stoppedContainerName], deploymentId, { redact: secrets });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      appendDeploymentLog(deploymentId, `Failed to restart previous stateful container: ${message}`, "stderr", secrets);
+    }
+  }
+
   if (shouldRestoreActivePort) {
     try {
       db.update(services).set({ activePort: previousActivePort, updatedAt: now() }).where(eq(services.id, serviceId)).run();
@@ -422,13 +467,6 @@ async function rollbackFailedWebRollout({
     }
   }
 
-  if (tempContainerName && shouldRemoveTempContainer) {
-    await removeDeploymentContainer({
-      containerName: tempContainerName,
-      log: (line, stream = "system") => appendDeploymentLog(deploymentId, line, stream, secrets),
-      runBufferedDocker: (args) => runBufferedCommand("docker", args)
-    });
-  }
 }
 
 async function cleanupInterruptedDeploymentContainers(interruptedDeployments: { id: string; serviceId: string; containerName: string | null }[]) {
@@ -961,6 +999,7 @@ async function runDeployment(deployment: Deployment, service: Service) {
     let webTempContainerPromoted = false;
     let webActivePortChanged = false;
     let webPreviousActivePort = service.activePort;
+    let webOldContainerStoppedForVolume = false;
     if (!imageName) {
       db.update(deployments)
         .set({ status: "failed", startedAt, finishedAt: now(), containerName })
@@ -1026,7 +1065,8 @@ async function runDeployment(deployment: Deployment, service: Service) {
           "unless-stopped",
           "--name",
           containerName,
-          ...runtimeNetworkArgs(service)
+          ...runtimeNetworkArgs(service),
+          ...applicationDataVolumeDockerArgs(service)
         ];
         for (const [key, value] of Object.entries(env)) {
           dockerArgs.push("--env", `${key}=${value}`);
@@ -1070,6 +1110,13 @@ async function runDeployment(deployment: Deployment, service: Service) {
       webTempContainerName = tempContainerName;
       appendDeploymentLog(deployment.id, `Allocated ephemeral port ${tempPort} for Docker image rollout.`);
 
+      webOldContainerStoppedForVolume = await stopExistingContainerForVolumeRollout({
+        service,
+        containerName,
+        deploymentId: deployment.id,
+        secrets
+      });
+
       const dockerArgs = [
         "run",
         "-d",
@@ -1078,6 +1125,7 @@ async function runDeployment(deployment: Deployment, service: Service) {
         "--name",
         tempContainerName,
         ...runtimeNetworkArgs(service),
+        ...applicationDataVolumeDockerArgs(service),
         "-p",
         `127.0.0.1:${tempPort}:${runtimePort}`
       ];
@@ -1122,7 +1170,11 @@ async function runDeployment(deployment: Deployment, service: Service) {
       await new Promise((resolvePromise) => setTimeout(resolvePromise, 300));
 
       appendDeploymentLog(deployment.id, `Stopping and removing old container ${containerName} if it exists...`);
-      await runCommand("docker", ["rm", "-f", containerName], deployment.id).catch(() => undefined);
+      await runCommand("docker", ["rm", "-f", containerName], deployment.id)
+        .then(() => {
+          webOldContainerStoppedForVolume = false;
+        })
+        .catch(() => undefined);
 
       appendDeploymentLog(deployment.id, `Renaming new container ${tempContainerName} to stable name ${containerName}...`);
       await runCommand("docker", ["rename", tempContainerName, containerName], deployment.id);
@@ -1155,6 +1207,7 @@ async function runDeployment(deployment: Deployment, service: Service) {
           shouldRestoreActivePort: webActivePortChanged && !webTempContainerPromoted,
           tempContainerName: webTempContainerName,
           shouldRemoveTempContainer: webTempContainerNeedsCleanup && !webTempContainerPromoted,
+          stoppedContainerName: webOldContainerStoppedForVolume ? containerName : null,
           secrets
         });
         return;
@@ -1171,6 +1224,7 @@ async function runDeployment(deployment: Deployment, service: Service) {
         shouldRestoreActivePort: webActivePortChanged && !webTempContainerPromoted,
         tempContainerName: webTempContainerName,
         shouldRemoveTempContainer: webTempContainerNeedsCleanup && !webTempContainerPromoted,
+        stoppedContainerName: webOldContainerStoppedForVolume ? containerName : null,
         secrets
       });
     }
@@ -1200,6 +1254,7 @@ async function runDeployment(deployment: Deployment, service: Service) {
   let webTempContainerPromoted = false;
   let webActivePortChanged = false;
   let webPreviousActivePort = service.activePort;
+  let webOldContainerStoppedForVolume = false;
 
   try {
     if (config.deployDryRun) {
@@ -1400,7 +1455,8 @@ async function runDeployment(deployment: Deployment, service: Service) {
         "unless-stopped",
         "--name",
         containerName,
-        ...runtimeNetworkArgs(service)
+        ...runtimeNetworkArgs(service),
+        ...applicationDataVolumeDockerArgs(service)
       ];
       for (const [key, value] of Object.entries(env)) {
         dockerArgs.push("--env", `${key}=${value}`);
@@ -1452,6 +1508,13 @@ async function runDeployment(deployment: Deployment, service: Service) {
     webTempContainerName = tempContainerName;
     appendDeploymentLog(deployment.id, `Allocated ephemeral port ${tempPort} for zero-downtime container rollout.`);
 
+    webOldContainerStoppedForVolume = await stopExistingContainerForVolumeRollout({
+      service,
+      containerName,
+      deploymentId: deployment.id,
+      secrets
+    });
+
     const dockerArgs = [
       "run",
       "-d",
@@ -1460,6 +1523,7 @@ async function runDeployment(deployment: Deployment, service: Service) {
       "--name",
       tempContainerName,
       ...runtimeNetworkArgs(service),
+      ...applicationDataVolumeDockerArgs(service),
       "-p",
       `127.0.0.1:${tempPort}:${runtimePort}`
     ];
@@ -1505,9 +1569,13 @@ async function runDeployment(deployment: Deployment, service: Service) {
     await new Promise((resolvePromise) => setTimeout(resolvePromise, 300));
 
     appendDeploymentLog(deployment.id, `Stopping and removing old container ${containerName} if it exists...`);
-    await runCommand("docker", ["rm", "-f", containerName], deployment.id).catch(() => {
-      // Ignore if no previous container was running
-    });
+    await runCommand("docker", ["rm", "-f", containerName], deployment.id)
+      .then(() => {
+        webOldContainerStoppedForVolume = false;
+      })
+      .catch(() => {
+        // Ignore if no previous container was running
+      });
 
     appendDeploymentLog(deployment.id, `Renaming new container ${tempContainerName} to stable name ${containerName}...`);
     await runCommand("docker", ["rename", tempContainerName, containerName], deployment.id);
@@ -1540,6 +1608,7 @@ async function runDeployment(deployment: Deployment, service: Service) {
         shouldRestoreActivePort: webActivePortChanged && !webTempContainerPromoted,
         tempContainerName: webTempContainerName,
         shouldRemoveTempContainer: webTempContainerNeedsCleanup && !webTempContainerPromoted,
+        stoppedContainerName: webOldContainerStoppedForVolume ? containerName : null,
         secrets
       });
       return;
@@ -1556,6 +1625,7 @@ async function runDeployment(deployment: Deployment, service: Service) {
       shouldRestoreActivePort: webActivePortChanged && !webTempContainerPromoted,
       tempContainerName: webTempContainerName,
       shouldRemoveTempContainer: webTempContainerNeedsCleanup && !webTempContainerPromoted,
+      stoppedContainerName: webOldContainerStoppedForVolume ? containerName : null,
       secrets
     });
   } finally {

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -16,6 +16,7 @@ import { Readable } from "node:stream";
 import { basename, join, resolve } from "node:path";
 import { z } from "zod";
 import { config } from "./config.js";
+import { isValidApplicationVolumePath } from "./application-volume.js";
 import { isPostgresFamilyDatabase } from "./database-engine.js";
 import { abortDeployment, allocateHostPort, containerNameForService, enqueueDeployment, getServiceById, removeServiceRuntime, startDeployWorker, staticSiteDirForService } from "./deploy.js";
 import { db, nowIso } from "./db.js";
@@ -206,6 +207,22 @@ const clearableDockerfilePath = z.preprocess((value) => {
   (value) => value === undefined || value === null || !value.split("/").includes(".."),
   { message: "Invalid Dockerfile path" }
 );
+const persistentVolumePath = z.preprocess((value) => {
+  if (typeof value !== "string") return value;
+  const trimmed = value.trim().replace(/\/+$/g, "");
+  return trimmed || undefined;
+}, z.string().max(4096).optional()).refine(
+  (value) => value === undefined || isValidApplicationVolumePath(value),
+  { message: "Persistent volume path must be a normalized absolute container path below /" }
+);
+const clearablePersistentVolumePath = z.preprocess((value) => {
+  if (typeof value !== "string") return value;
+  const trimmed = value.trim().replace(/\/+$/g, "");
+  return trimmed || null;
+}, z.string().max(4096).nullable().optional()).refine(
+  (value) => value === undefined || value === null || isValidApplicationVolumePath(value),
+  { message: "Persistent volume path must be a normalized absolute container path below /" }
+);
 const repoSchema = z.string().trim().min(1).refine((value) => {
   return value.startsWith("https://") || value.startsWith("git@") || value === "database" || value === DOCKER_IMAGE_REPO_URL || value === FUNCTION_REPO_URL;
 }, {
@@ -257,6 +274,7 @@ const serviceSettingsSchema = z.object({
   staticOutput: optionalString,
   buildMethod: z.enum(serviceBuildMethods).optional(),
   dockerfilePath: optionalDockerfilePath,
+  persistentVolumePath,
   runtimeMode: serviceRuntimeModeSchema,
   internalPort: z.coerce.number().int().min(1).max(65535).default(8080),
   databasePublicEnabled: z.boolean().optional().default(true),
@@ -495,6 +513,7 @@ const updateServiceSchema = z.object({
   staticOutput: clearableString,
   buildMethod: z.enum(serviceBuildMethods).optional(),
   dockerfilePath: clearableDockerfilePath,
+  persistentVolumePath: clearablePersistentVolumePath,
   runtimeMode: z.enum(serviceRuntimeModes).optional(),
   internalPort: z.coerce.number().int().min(1).max(65535).optional(),
   databasePublicEnabled: z.boolean().optional(),
@@ -831,6 +850,7 @@ async function publicService(service: Service, options: PublicServiceOptions = {
     staticOutput: service.staticOutput,
     buildMethod: normalizeServiceBuildMethod(service.buildMethod),
     dockerfilePath: service.dockerfilePath,
+    persistentVolumePath: service.persistentVolumePath,
     detectedBuildMethod: service.detectedBuildMethod,
     runtimeMode: normalizeServiceRuntimeMode(service.runtimeMode),
     internalPort: service.internalPort,
@@ -915,6 +935,7 @@ function createServiceRecord(projectId: string, input: z.infer<typeof createServ
     staticOutput: isFunction ? null : input.staticOutput ?? null,
     buildMethod: isFunction ? "dockerfile" : input.buildMethod ?? "auto",
     dockerfilePath: isFunction ? "Dockerfile" : input.dockerfilePath ?? null,
+    persistentVolumePath: isDatabase || isFunction || input.staticOutput ? null : input.persistentVolumePath ?? null,
     detectedBuildMethod: null,
     runtimeMode: isDatabase || input.staticOutput ? "web" : input.runtimeMode,
     internalPort: input.internalPort,
@@ -2861,6 +2882,7 @@ app.patch("/api/services/:serviceId", async (c) => {
     repoUrl = DOCKER_IMAGE_REPO_URL;
   }
   const nextIsDatabase = isDatabaseService({ repoFullName, repoUrl });
+  const nextIsFunction = isFunctionService({ repoFullName, repoUrl });
   const nextDatabaseType = nextIsDatabase ? databaseTypeForService({ repoFullName, repoUrl }) : "";
   const databasePublicEnabled = nextIsDatabase;
   const databasePublicHostname = nextIsDatabase
@@ -2871,6 +2893,11 @@ app.patch("/api/services/:serviceId", async (c) => {
       ? updateData.postgresLogicalReplicationEnabled ?? service.postgresLogicalReplicationEnabled
       : false;
   const nextStaticOutput = updateData.staticOutput === undefined ? service.staticOutput : updateData.staticOutput;
+  const nextPersistentVolumePath = nextIsDatabase || nextIsFunction || nextStaticOutput
+    ? null
+    : updateData.persistentVolumePath === undefined
+      ? service.persistentVolumePath
+      : updateData.persistentVolumePath;
   const runtimeMode = nextIsDatabase || nextStaticOutput
     ? "web"
     : normalizeServiceRuntimeMode(updateData.runtimeMode ?? service.runtimeMode);
@@ -2881,6 +2908,7 @@ app.patch("/api/services/:serviceId", async (c) => {
       repoFullName,
       repoUrl,
       githubToken: updateData.githubToken === undefined ? service.githubToken : updateData.githubToken ?? null,
+      persistentVolumePath: nextPersistentVolumePath,
       runtimeMode,
       ...(runtimeMode === "worker" ? { activePort: null } : {}),
       databasePublicEnabled,

--- a/src/server/schema.ts
+++ b/src/server/schema.ts
@@ -28,6 +28,7 @@ export const services = sqliteTable("projects", {
   staticOutput: text("static_output"),
   buildMethod: text("build_method").notNull().default("auto"),
   dockerfilePath: text("dockerfile_path"),
+  persistentVolumePath: text("persistent_volume_path"),
   detectedBuildMethod: text("detected_build_method"),
   runtimeMode: text("runtime_mode").notNull().default("web"),
   internalPort: integer("internal_port").notNull(),


### PR DESCRIPTION
## Summary

- add an optional persistent volume path to application and Docker image services
- validate and persist volume settings through the API and database schema
- mount service-specific Docker volumes during deployments
- protect stateful rollouts by stopping and restoring existing containers when needed
- clarify maintenance cleanup warnings for persistent application data

Closes #20

## Validation

- `git diff --check main...HEAD`
- full build/browser checks not run per repository instructions