### PR TITLE
Fix Docker network address pool exhaustion

### DIFF
--- a/src/client/api.ts
+++ b/src/client/api.ts
@@ -533,6 +533,7 @@ export type SystemUpdateInfo = {
 
 export type MaintenanceCleanupTarget =
   | "docker-containers"
+  | "docker-networks"
   | "docker-images"
   | "docker-build-cache"
   | "docker-volumes"

--- a/src/client/components/modals/maintenance-utils.ts
+++ b/src/client/components/modals/maintenance-utils.ts
@@ -3,6 +3,7 @@ import { formatBytes } from "../../lib/format";
 
 export const safeCleanupTargets = [
   "docker-containers",
+  "docker-networks",
   "docker-images",
   "docker-build-cache",
   "apt-cache",

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -28,6 +28,7 @@ import { envExampleVariableSuggestions } from "./env-example-suggestions.js";
 import { resolveServiceEnv } from "./variable-resolver.js";
 import { getRailwayProjects, getRailwayProjectDetails, importRailwayProject } from "./railway-importer.js";
 import { startRailwayImportAutomation } from "./railway-import-automation.js";
+import { removeProjectRuntimeNetwork } from "./runtime-network.js";
 import { getVercelTeams, getVercelProjects, getVercelProjectDetails, importVercelProject } from "./vercel-importer.js";
 import {
   createDefaultProjectEnvironments,
@@ -3123,6 +3124,7 @@ app.delete("/api/projects/:projectId", async (c) => {
     db.delete(services).where(eq(services.id, service.id)).run();
   }
 
+  await removeProjectRuntimeNetwork(project.id);
   db.delete(projectGroups).where(eq(projectGroups.id, project.id)).run();
   const caddy = await writeAndReloadCaddy();
   return c.json({ ok: true, caddy });

--- a/src/server/runtime-network.ts
+++ b/src/server/runtime-network.ts
@@ -1,4 +1,5 @@
 import { createHash } from "node:crypto";
+import { spawn } from "node:child_process";
 import { eq } from "drizzle-orm";
 import { config } from "./config.js";
 import { db } from "./db.js";
@@ -24,6 +25,11 @@ type ContainerInspect = {
 };
 
 const maxDockerNetworkNameLength = 63;
+const managedNetworkLabel = "io.aeroplane.managed=true";
+const projectNetworkLabel = "io.aeroplane.project";
+const projectNetworkSecondOctetStart = 64;
+const projectNetworkSecondOctetCount = 64;
+const projectNetworkCreationAttempts = 256;
 
 function safeDockerNetworkPart(value: string, fallback: string) {
   return value.replace(/[^a-zA-Z0-9_.-]+/g, "-").replace(/^[^a-zA-Z0-9]+|[^a-zA-Z0-9]+$/g, "") || fallback;
@@ -52,6 +58,27 @@ export function runtimeNetworkArgs(service: Pick<Service, "projectId" | "slug">)
   return ["--network", runtimeNetworkNameForService(service), "--network-alias", service.slug];
 }
 
+export function removeProjectRuntimeNetwork(projectId: string) {
+  const networkName = runtimeNetworkNameForProject(projectId);
+  return new Promise<void>((resolvePromise) => {
+    const child = spawn("docker", ["network", "rm", networkName], {
+      stdio: ["ignore", "ignore", "pipe"]
+    });
+    let errorOutput = "";
+
+    child.stderr.on("data", (chunk: Buffer) => {
+      errorOutput += chunk.toString();
+    });
+    child.on("error", () => resolvePromise());
+    child.on("close", (code) => {
+      if (code !== 0 && !/not found|no such network/i.test(errorOutput)) {
+        console.warn(`Could not remove Docker project runtime network ${networkName}: ${errorOutput.trim()}`);
+      }
+      resolvePromise();
+    });
+  });
+}
+
 function parseContainerInspect(stdout: string): ContainerInspect | null {
   try {
     const parsed = JSON.parse(stdout) as ContainerInspect[];
@@ -64,6 +91,48 @@ function parseContainerInspect(stdout: string): ContainerInspect | null {
 function isDockerAlreadyExistsError(error: unknown) {
   const message = error instanceof Error ? error.message : String(error);
   return /already exists/i.test(message);
+}
+
+function isDockerSubnetConflictError(error: unknown) {
+  const message = error instanceof Error ? error.message : String(error);
+  return /pool overlaps|address.*already in use|overlap.*address space/i.test(message);
+}
+
+function projectNetworkSubnet(projectId: string, attempt: number) {
+  const subnetCount = projectNetworkSecondOctetCount * 256;
+  const seed = createHash("sha256").update(projectId).digest().readUInt16BE(0);
+  const subnetIndex = (seed + attempt) % subnetCount;
+  const secondOctet = projectNetworkSecondOctetStart + Math.floor(subnetIndex / 256);
+  const thirdOctet = subnetIndex % 256;
+  return `10.${secondOctet}.${thirdOctet}.0/24`;
+}
+
+async function createProjectRuntimeNetwork(service: RuntimeNetworkService, networkName: string, runDocker: RunDocker) {
+  let lastConflict: unknown = null;
+
+  for (let attempt = 0; attempt < projectNetworkCreationAttempts; attempt += 1) {
+    try {
+      await runDocker([
+        "network",
+        "create",
+        "--driver",
+        "bridge",
+        "--subnet",
+        projectNetworkSubnet(service.projectId, attempt),
+        "--label",
+        managedNetworkLabel,
+        "--label",
+        `${projectNetworkLabel}=${service.projectId}`,
+        networkName
+      ]);
+      return;
+    } catch (error) {
+      if (!isDockerSubnetConflictError(error)) throw error;
+      lastConflict = error;
+    }
+  }
+
+  throw lastConflict ?? new Error(`Could not allocate a private subnet for ${networkName}`);
 }
 
 async function inspectContainer(containerName: string, runBufferedDocker: RunBufferedDocker) {
@@ -148,7 +217,8 @@ export async function ensureProjectRuntimeNetwork({
   if (existing.code !== 0) {
     log?.(`Creating Docker project runtime network ${networkName}.`);
     try {
-      await runDocker(["network", "create", networkName]);
+      // Explicit /24s avoid Docker's large automatic subnets and continue working when its default pools are exhausted.
+      await createProjectRuntimeNetwork(service, networkName, runDocker);
     } catch (error) {
       if (!isDockerAlreadyExistsError(error)) {
         throw error;

--- a/src/server/system-maintenance.ts
+++ b/src/server/system-maintenance.ts
@@ -6,6 +6,7 @@ import { config } from "./config.js";
 
 export const maintenanceCleanupTargets = [
   "docker-containers",
+  "docker-networks",
   "docker-images",
   "docker-build-cache",
   "docker-volumes",
@@ -357,6 +358,11 @@ async function runCleanupTarget(target: MaintenanceCleanupTarget): Promise<Maint
       label: "Stopped Docker containers",
       command: "docker",
       args: ["container", "prune", "-f"]
+    },
+    "docker-networks": {
+      label: "Unused Docker networks",
+      command: "docker",
+      args: ["network", "prune", "-f"]
     },
     "docker-images": {
       label: "Unused Docker images",


### PR DESCRIPTION
## Summary

- allocate deterministic private `/24` subnets for new project runtime networks instead of consuming Docker default address pools
- retry subnet allocation when a candidate overlaps an existing Docker network
- label new networks with Aeroplane ownership and project metadata
- remove a project runtime network when the project is deleted
- include unused Docker networks in System Maintenance safe cleanup

## Context

Database provisioning failed with `all predefined address pools have been fully subnetted` after project networks exhausted Docker automatic subnet allocation. Existing networks are left untouched; new networks use explicit `10.64.0.0/10`-range `/24`s.

## Verification

- `git diff --check`
- validated the exact network creation flags on the affected fully-exhausted Docker daemon
- confirmed the allocated `/24` subnet and both labels via `docker network inspect`
- removed the temporary verification network
- build and browser tests not run per repository instructions

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes database provisioning failures caused by Docker's automatic subnet allocation being exhausted by project runtime networks.

New project runtime networks now use deterministic `/24` subnets from the `10.64.0.0/10` range, retrying on address conflicts instead of consuming Docker's default address pools. Existing networks are left untouched.

**Network lifecycle**

- Removes a project's runtime network when the project is deleted.
- Adds unused Docker networks to System Maintenance safe cleanup.
- Labels new networks with Aeroplane ownership and project ID.

<sup>Written for commit 72e686fd2f824725f35c70a00b01f8cbee0f7d53. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/xt42io/aeroplane/pull/27?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

